### PR TITLE
Fixed full screen video player initial orientation issue

### DIFF
--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
@@ -14,7 +14,8 @@ public class AwesomeVideoFullscreenPlayer: UIViewController {
     private var isPlaying: Bool
     private var previousFrame: CGRect
     private var previousCentre: CGPoint
-        
+    public var defaultInterfaceOrientation: UIInterfaceOrientation = .landscapeLeft
+
     override public var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
@@ -32,6 +33,13 @@ public class AwesomeVideoFullscreenPlayer: UIViewController {
     }
 
     override public var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        let currentOrientation = UIApplication.shared.statusBarOrientation
+        switch currentOrientation {
+        case .portrait, .portraitUpsideDown:
+            return defaultInterfaceOrientation
+        default:
+            break
+        }
         return UIApplication.shared.statusBarOrientation
     }
     

--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
@@ -32,7 +32,7 @@ public class AwesomeVideoFullscreenPlayer: UIViewController {
     }
 
     override public var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        return .landscapeLeft
+        return UIApplication.shared.statusBarOrientation
     }
     
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
@@ -38,9 +38,8 @@ public class AwesomeVideoFullscreenPlayer: UIViewController {
         case .portrait, .portraitUpsideDown:
             return defaultInterfaceOrientation
         default:
-            break
+            return UIApplication.shared.statusBarOrientation
         }
-        return UIApplication.shared.statusBarOrientation
     }
     
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {


### PR DESCRIPTION
##JIRA
n/a

##Description
When rotating the Fullscreen video player, it would always auto rotate to Landscape left and completely rotate the screen to that orientation even when rotating to landscape right resulting in a flipped video.

I have fixed this by reading the orientation of the screen at the time the full screen video player appears, if the full screen video player is presented and the device is in portrait it will default to landscape left unless the initial orientation property is changed. 
The default orientation is ignored on the iPad.

##Screenshots
**Before:**
![Screen Recording 2020-05-13 at 09 26 55 mov](https://user-images.githubusercontent.com/618350/81790243-0b925e80-94fd-11ea-8293-cdbd0fc643d7.gif)

**After:**
![fixed](https://user-images.githubusercontent.com/618350/81790447-50b69080-94fd-11ea-8fb9-1a7adeb7ea25.gif)

