### PR TITLE
Update AdMob Rewarded Video Ads to the latest version

### DIFF
--- a/Adapters/AdMob/Classes/SAAdMobRewardedAd.h
+++ b/Adapters/AdMob/Classes/SAAdMobRewardedAd.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+@import GoogleMobileAds;
+
+@interface SAAdMobRewardedAd : NSObject <GADMediationRewardedAd>
+
+- (void)loadRewardedAdForAdConfiguration: (GADMediationRewardedAdConfiguration *) adConfiguration
+                       completionHandler: (GADMediationRewardedLoadCompletionHandler) completionHandler;
+
+@end

--- a/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
+++ b/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
@@ -1,0 +1,132 @@
+#import "SAAdMobRewardedAd.h"
+#import "SAAdMobExtras.h"
+#import <SuperAwesome/SAVersion.h>
+#import <SuperAwesome/SuperAwesome-Swift.h>
+#include <stdatomic.h>
+
+#define kERROR_DOMAIN @"tv.superawesome.SAAdMobVideoMediationAdapter"
+
+@interface SAAdMobRewardedAd () <GADMediationRewardedAd> {
+    
+}
+
+/// Placement Id for requested ad
+@property (nonatomic, assign) NSInteger placementId;
+
+/// An ad event delegate to invoke when ad rendering events occur.
+@property (nonatomic, weak, nullable) id<GADMediationRewardedAdEventDelegate> delegate;
+
+@end
+
+@implementation SAAdMobRewardedAd {
+    /// The completion handler to call when the ad loading succeeds or fails.
+    GADMediationRewardedLoadCompletionHandler _completionHandler;
+}
+
+- (void)loadRewardedAdForAdConfiguration: (nonnull GADMediationRewardedAdConfiguration *)adConfiguration
+                       completionHandler: (nonnull GADMediationRewardedLoadCompletionHandler)completionHandler {
+    
+    __block atomic_flag completionHandlerCalled = ATOMIC_FLAG_INIT;
+    __block GADMediationRewardedLoadCompletionHandler originalCompletionHandler = [completionHandler copy];
+    _completionHandler = ^id<GADMediationRewardedAdEventDelegate>(
+                                                                  id<GADMediationRewardedAd> rewardedAd, NSError *error) {
+        if (atomic_flag_test_and_set(&completionHandlerCalled)) {
+            return nil;
+        }
+        id<GADMediationRewardedAdEventDelegate> delegate = nil;
+        if (originalCompletionHandler) {
+            delegate = originalCompletionHandler(rewardedAd, error);
+        }
+        originalCompletionHandler = nil;
+        return delegate;
+    };
+    
+    NSString *parameter = [adConfiguration.credentials.settings objectForKey:GADCustomEventParametersServer];
+    _placementId = [parameter integerValue];
+    
+    if (_placementId == 0) {
+        NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
+        completionHandler(nil, error);
+        return;
+    }
+
+    SAAdMobVideoExtra *extras = adConfiguration.extras;
+    if (extras != nil) {
+        [SAVideoAd setTestMode:extras.testEnabled];
+        [SAVideoAd setOrientation:extras.orientation];
+        [SAVideoAd setParentalGate:extras.parentalGateEnabled];
+        [SAVideoAd setBumperPage:extras.bumperPageEnabled];
+        [SAVideoAd setCloseButton:extras.closeButtonEnabled];
+        [SAVideoAd setCloseAtEnd:extras.closeAtEndEnabled];
+        [SAVideoAd setSmallClick:extras.smallCLickEnabled];
+        [SAVideoAd setConfiguration:extras.configuration];
+        [SAVideoAd setPlaybackMode:extras.playback];
+    }
+    
+    [self requestVideoAd];
+}
+
+- (void) adLoaded {
+    _delegate = _completionHandler(self, nil);
+}
+
+- (void) adFailed {
+    NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
+    [_delegate didFailToPresentWithError:error];
+}
+
+- (void) requestVideoAd {
+    __weak typeof (self) weakSelf = self;
+    
+    [SAVideoAd setCallback:^(NSInteger placementId, SAEvent event) {
+        
+        switch (event) {
+            case adLoaded: {
+                [weakSelf adLoaded];
+                break;
+            }
+            case adEmpty: {
+                [weakSelf adFailed];
+                break;
+            }
+            case adFailedToLoad: {
+                [weakSelf adFailed];
+                break;
+            }
+            case adShown: {
+                [weakSelf.delegate willPresentFullScreenView];
+                break;
+            }
+            case adClicked: {
+                [weakSelf.delegate reportClick];
+                [weakSelf.delegate willDismissFullScreenView];
+                break;
+            }
+            case adClosed: {
+                [weakSelf.delegate willDismissFullScreenView];
+                [weakSelf.delegate didDismissFullScreenView];
+                break;
+            }
+            case adAlreadyLoaded:
+            case adFailedToShow:
+            case adEnded:
+                break;
+        }
+    }];
+    
+    [SAVideoAd load: _placementId];
+}
+
+- (void)presentFromViewController:(nonnull UIViewController *)viewController {
+    if ([SAVideoAd hasAdAvailable: _placementId]) {
+        [SAVideoAd play: _placementId fromVC:viewController];
+    } else {
+        NSError *error =
+        [NSError errorWithDomain:@"SAAdMobRewardedAd"
+                            code:0
+                        userInfo:@{NSLocalizedDescriptionKey : @"Unable to display ad."}];
+        [self.delegate didFailToPresentWithError:error];
+    }
+}
+
+@end

--- a/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.h
+++ b/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <GoogleMobileAds/GoogleMobileAds.h>
+@import GoogleMobileAds;
 
-@interface SAAdMobVideoMediationAdapter : NSObject <GADMRewardBasedVideoAdNetworkAdapter>
+@interface SAAdMobVideoMediationAdapter : NSObject <GADMediationAdapter>
 @end

--- a/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.m
+++ b/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.m
@@ -1,170 +1,55 @@
 #import "SAAdMobVideoMediationAdapter.h"
 #import "SAAdMobExtras.h"
 #import <SuperAwesome/SAVersion.h>
-#import <SuperAwesome/SuperAwesome-Swift.h>
+#import "SAAdMobRewardedAd.h"
+#include <stdatomic.h>
 
 #define kERROR_DOMAIN @"tv.superawesome.SAAdMobVideoMediationAdapter"
 
-@interface SAAdMobVideoMediationAdapter ()
+@implementation SAAdMobVideoMediationAdapter {
+    SAAdMobRewardedAd *_rewardedAd;
+}
 
-//
-// placement ID
-@property (nonatomic, assign) NSInteger placementId;
++ (GADVersionNumber)adSDKVersion {
+    NSString *versionString = [SAVersion getSdkVersion];
+    NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
+    GADVersionNumber version = {0};
+    if (versionComponents.count == 3) {
+        version.majorVersion = [versionComponents[0] integerValue];
+        version.minorVersion = [versionComponents[1] integerValue];
+        version.patchVersion = [versionComponents[2] integerValue];
+    }
+    return version;
+}
 
-//
-// anon variable, respecting GADMRewardBasedVideoAdNetworkConnector, acting
-// as connector
-@property (nonatomic, weak) id<GADMRewardBasedVideoAdNetworkConnector> connector;
-
-@end
-
-@implementation SAAdMobVideoMediationAdapter
++ (GADVersionNumber)version {
+    NSString *versionString = [NSString stringWithFormat:@"%@.0", [SAVersion getSdkVersion]];
+    NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
+    GADVersionNumber version = {0};
+    if (versionComponents.count == 4) {
+        version.majorVersion = [versionComponents[0] integerValue];
+        version.minorVersion = [versionComponents[1] integerValue];
+        
+        // Adapter versions have 2 patch versions. Multiply the first patch by 100.
+        version.patchVersion = [versionComponents[2] integerValue] * 100
+        + [versionComponents[3] integerValue];
+    }
+    return version;
+}
 
 + (NSString *)adapterVersion {
-    //
-    // just return the current SA SDK version
     return [SAVersion getSdkVersion];
 }
 
 + (Class<GADAdNetworkExtras>)networkExtrasClass {
-    //
-    // expect that if users send extra info, it's going to be
-    // as SAAdMobVideoExtra class
     return [SAAdMobVideoExtra class];
 }
 
-- (instancetype) initWithRewardBasedVideoAdNetworkConnector: (id<GADMRewardBasedVideoAdNetworkConnector>)connector{
-    
-    //
-    // Step 1. if connector is nil, then fail silently
-    if (!connector) {
-        return nil;
-    }
-    
-    //
-    // Step 2. Init the ad
-    self = [super init];
-    if (self) {
-        _connector = connector;
-    }
-    return self;
-}
-
-- (void) setUp {
-    
-    //
-    // Step 3: try and get the placement Id
-    NSString *parameter = [self.connector.credentials objectForKey:GADCustomEventParametersServer];
-    _placementId = [parameter integerValue];
-    
-    //
-    // Step 3.1. if placement Id is 0, then it was sent wrong by the server
-    // and I should abort
-    if (_placementId == 0) {
-        NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
-        [_connector adapter:self didFailToSetUpRewardBasedVideoAdWithError:error];
-        return;
-    }
-    
-    //
-    // Step 4. get all extras that might help customise this ad
-    SAAdMobVideoExtra *extras = [self.connector networkExtras];
-    
-    if (extras != nil) {
-        [SAVideoAd setTestMode:extras.testEnabled];
-        [SAVideoAd setOrientation:extras.orientation];
-        [SAVideoAd setParentalGate:extras.parentalGateEnabled];
-        [SAVideoAd setBumperPage:extras.bumperPageEnabled];
-        [SAVideoAd setCloseButton:extras.closeButtonEnabled];
-        [SAVideoAd setCloseAtEnd:extras.closeAtEndEnabled];
-        [SAVideoAd setSmallClick:extras.smallCLickEnabled];
-        [SAVideoAd setConfiguration:extras.configuration];
-        [SAVideoAd setPlaybackMode:extras.playback];
-    }
-    
-    //
-    // Step 5. finally, if I've gotten to here, I've setup the video ad
-    // correctly adns hould proceed
-    [_connector adapterDidSetUpRewardBasedVideoAd:self];
-}
-
-- (void) requestRewardBasedVideoAd {
-    
-    __weak typeof (self) weakSelf = self;
-    
-    //
-    // Step 6. Add a callback
-    [SAVideoAd setCallback:^(NSInteger placementId, SAEvent event) {
-        
-        switch (event) {
-            case adLoaded: {
-                //
-                // send event to AdMob
-                [weakSelf.connector adapterDidReceiveRewardBasedVideoAd:weakSelf];
-                break;
-            }
-            case adEmpty: {
-                //
-                // send error info to AdMob
-                NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
-                [weakSelf.connector adapter:weakSelf didFailToLoadRewardBasedVideoAdwithError:error];
-                break;
-            }
-            case adFailedToLoad: {
-                //
-                // send error info to AdMob
-                NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
-                [weakSelf.connector adapter:weakSelf didFailToLoadRewardBasedVideoAdwithError:error];
-                break;
-            }
-            case adShown: {
-                //
-                // send open & play to AdMob
-                [weakSelf.connector adapterDidOpenRewardBasedVideoAd:weakSelf];
-                [weakSelf.connector adapterDidStartPlayingRewardBasedVideoAd:weakSelf];
-                break;
-            }
-            case adClicked: {
-                //
-                // send click & leve to AdMob
-                [weakSelf.connector adapterDidGetAdClick:weakSelf];
-                [weakSelf.connector adapterWillLeaveApplication:weakSelf];
-                break;
-            }
-            case adClosed: {
-                //
-                // send close to AdMob
-                [weakSelf.connector adapterDidCloseRewardBasedVideoAd:weakSelf];
-                break;
-            }
-            //
-            // non supported SA events
-            case adAlreadyLoaded:
-            case adFailedToShow:
-            case adEnded:
-                break;
-            
-        }
-        
-    }];
-    
-    //
-    // Step 7. actually load Ad
-    [SAVideoAd load:_placementId];
-    
-}
-
-- (void) presentRewardBasedVideoAdWithRootViewController:(UIViewController *)viewController {
-    //
-    // Step 8. If SA says we have an ad, play it from the root controller
-    // indicated by AdMob
-    if ([SAVideoAd hasAdAvailable:_placementId]) {
-        [SAVideoAd play:_placementId fromVC:viewController];
-    }
-}
-
-- (void) stopBeingDelegate {
-    // do nothing
+- (void)loadRewardedAdForAdConfiguration: (GADMediationRewardedAdConfiguration *)adConfiguration
+                       completionHandler: (GADMediationRewardedLoadCompletionHandler)completionHandler {
+    _rewardedAd = [[SAAdMobRewardedAd alloc] init];
+    [_rewardedAd loadRewardedAdForAdConfiguration:adConfiguration
+                                completionHandler:completionHandler];
 }
 
 @end

--- a/Adapters/AdMob/Example/Podfile.lock
+++ b/Adapters/AdMob/Example/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.59.0):
+  - Google-Mobile-Ads-SDK (7.62.0):
     - GoogleAppMeasurement (~> 6.0)
-  - GoogleAppMeasurement (6.6.1):
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
-    - GoogleUtilities/MethodSwizzler (~> 6.0)
-    - GoogleUtilities/Network (~> 6.0)
-    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+  - GoogleAppMeasurement (6.7.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
+    - GoogleUtilities/MethodSwizzler (~> 6.7)
+    - GoogleUtilities/Network (~> 6.7)
+    - "GoogleUtilities/NSData+zlib (~> 6.7)"
     - nanopb (~> 1.30905.0)
-  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
+  - GoogleUtilities/AppDelegateSwizzler (6.7.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.6.0):
+  - GoogleUtilities/Environment (6.7.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.6.0):
+  - GoogleUtilities/Logger (6.7.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.6.0):
+  - GoogleUtilities/MethodSwizzler (6.7.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.6.0):
+  - GoogleUtilities/Network (6.7.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.6.0)"
-  - GoogleUtilities/Reachability (6.6.0):
+  - "GoogleUtilities/NSData+zlib (6.7.1)"
+  - GoogleUtilities/Reachability (6.7.1):
     - GoogleUtilities/Logger
   - nanopb (1.30905.0):
     - nanopb/decode (= 1.30905.0)
@@ -30,11 +30,16 @@ PODS:
   - nanopb/decode (1.30905.0)
   - nanopb/encode (1.30905.0)
   - PromisesObjC (1.2.9)
-  - SuperAwesome (7.2.7):
-    - SuperAwesome/Full (= 7.2.7)
-  - SuperAwesome/Full (7.2.7)
-  - SuperAwesomeAdMob (7.2.7):
-    - Google-Mobile-Ads-SDK (= 7.59)
+  - SuperAwesome (7.2.10):
+    - SuperAwesome/Full (= 7.2.10)
+  - SuperAwesome/Base (7.2.10)
+  - SuperAwesome/Full (7.2.10):
+    - SuperAwesome/Base
+    - SuperAwesome/Moat
+  - SuperAwesome/Moat (7.2.10):
+    - SuperAwesome/Base
+  - SuperAwesomeAdMob (7.2.10):
+    - Google-Mobile-Ads-SDK (= 7.62)
     - SuperAwesome (~> 7.2)
 
 DEPENDENCIES:
@@ -54,13 +59,13 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: 118217ac8b80e28aabe0c00aedab1cd885857776
-  GoogleAppMeasurement: 2fd5c5a56c069db635c8e7b92d4809a9591d0a69
-  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
+  Google-Mobile-Ads-SDK: c92c27666fbf684c964259785a6b3cdd3068e06f
+  GoogleAppMeasurement: 345d365fd105e6682bf5084783a5352a3db26820
+  GoogleUtilities: e121a3867449ce16b0e35ddf1797ea7a389ffdf2
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
   PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
-  SuperAwesome: 8aa6565d25ecbd8ca2ce69ac0285678125765764
-  SuperAwesomeAdMob: 6f35d4dff83e013f488762e88f6dc3998866dcc3
+  SuperAwesome: c3dec103b21dea8e0a6a1ed3f1ac45109167ff7b
+  SuperAwesomeAdMob: b6735bf1dfefbc42a248e2e2c14c8afe5ca1d738
 
 PODFILE CHECKSUM: be03e7f6c710c004e8a330f0c687fb673e9a00a8
 

--- a/Adapters/AdMob/Example/SuperAwesomeAdMob/AdMobViewController.swift
+++ b/Adapters/AdMob/Example/SuperAwesomeAdMob/AdMobViewController.swift
@@ -70,8 +70,8 @@ class AdMobViewController: UIViewController {
         let extra = SAAdMobVideoExtra()
         extra.testEnabled = false
         extra.closeAtEndEnabled = true
-        extra.closeButtonEnabled = false
-        extra.parentalGateEnabled = false
+        extra.closeButtonEnabled = true
+        extra.parentalGateEnabled = true
         extra.smallCLickEnabled = true
         //extra.configuration = STAGING;
         //extra.orientation = LANDSCAPE;

--- a/SuperAwesomeAdMob.podspec
+++ b/SuperAwesomeAdMob.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Adapters/AdMob/Classes/**/*'
   s.dependency 'SuperAwesome', '~> 7.2'
-  s.dependency 'Google-Mobile-Ads-SDK', '7.59'
+  s.dependency 'Google-Mobile-Ads-SDK', '7.62'
   s.xcconfig = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ADMOB_PLUGIN',
                  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) ADMOB_PLUGIN=1' }
 end


### PR DESCRIPTION
Update AdMob Rewarded Video Ads to the latest version, Remove deprecated `RewardBasedVideoAd` and use `RewardedAd`