### PR TITLE
Video playback reporting ad close incorrectly before dismissing ad

### DIFF
--- a/Pod/Classes/Video/VideoViewController.swift
+++ b/Pod/Classes/Video/VideoViewController.swift
@@ -226,7 +226,8 @@ import UIKit
     private func closeAction() {
         videoPlayer.destroy()
         SAParentalGate.close()
-        callback?(ad.placementId, SAEvent.adClosed)
-        dismiss(animated: true)
+        dismiss(animated: true) {
+            self.callback?(self.ad.placementId, SAEvent.adClosed)
+        }
     }
 }


### PR DESCRIPTION
The bug we experienced had to do with presenting a view controller after closing the interstitial ad unit. The problem was that before the ad was dismissed AA was notifying MoPub that the ad was already successfully closed when it was not. This caused our own presentation to fail. Adding a completion block to the dismiss call provides proper notification when the ad has been successfully closed.