### PR TITLE
fix: #145 SwiftyXMLParser causes Podfile installation failure by updating

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (5.4.4)
+  - Alamofire (5.5.0)
   - Mockingjay (2.0.1):
     - Mockingjay/Core (= 2.0.1)
     - Mockingjay/XCTest (= 2.0.1)
@@ -27,8 +27,8 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - SuperAwesome (8.1.3):
     - Moya (~> 14.0)
-    - SwiftyXMLParser (= 4.3.0)
-  - SwiftyXMLParser (4.3.0)
+    - SwiftyXMLParser (= 5.6.0)
+  - SwiftyXMLParser (5.6.0)
   - URITemplate (2.0.3)
 
 DEPENDENCIES:
@@ -52,13 +52,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
   Mockingjay: 11a621880d2887f1775bdcf824341eb68f218450
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  SuperAwesome: d2ea4e08e3700083ca05f0071b75cb3682e7023b
-  SwiftyXMLParser: b2e0b0dd0e0fb1ac39869dd4a0c6181847af2945
+  SuperAwesome: d03e3695fee5929904664fa002131f089402472d
+  SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
   URITemplate: ace0c4c46dcf8afe6e89b4060621852886b15c3b
 
 PODFILE CHECKSUM: 1ab632067b970ad603ba7c42b3da85378e54766f

--- a/SuperAwesome.podspec
+++ b/SuperAwesome.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   }
   s.static_framework = false
 
-  s.dependency 'SwiftyXMLParser', '4.3.0'
+  s.dependency 'SwiftyXMLParser', '5.6.0'
   s.dependency 'Moya', '~> 14.0'
   s.source_files = 'Pod/Classes/**/*'
   s.vendored_frameworks = 'Pod/Libraries/SUPMoatMobileAppKit.framework'


### PR DESCRIPTION
`SwiftyXMLParser` causes Podfile installation failure, updating to the latest version 