### PR TITLE
chore(): add debug logs for adLoaded, adShown, adClicked, adClosed and adEnded

### DIFF
--- a/Pod/Classes/UI/Common/AdController.swift
+++ b/Pod/Classes/UI/Common/AdController.swift
@@ -86,13 +86,17 @@ class AdController: AdControllerType, Injectable {
 
     func close() {
         callback?(placementId, .adClosed)
+        logger.success("Event callback: adClosed")
         adResponse = nil
         closed = true
     }
 
     func adFailedToShow() { callback?(placementId, .adFailedToShow) }
 
-    func adShown() { callback?(placementId, .adShown) }
+    func adShown() {
+        callback?(placementId, .adShown)
+        logger.success("Event callback: adShown")
+    }
 
     func adEnded() { callback?(placementId, .adEnded) }
 
@@ -136,6 +140,7 @@ class AdController: AdControllerType, Injectable {
         logger.success("Ad load successful for \(response.placementId)")
         adResponse = response
         callback?(placementId, .adLoaded)
+        logger.success("Event callback: adLoaded")
     }
 
     private func onFailure(_ error: Error) {
@@ -170,6 +175,7 @@ class AdController: AdControllerType, Injectable {
         lastClickTime = currentTime
 
         callback?(placementId, .adClicked)
+        logger.success("Event callback: adClicked")
 
         if adResponse.advert.creative.format == .video {
             eventRepository.videoClick(adResponse, completion: nil)

--- a/Pod/Classes/UI/Common/AdController.swift
+++ b/Pod/Classes/UI/Common/AdController.swift
@@ -86,7 +86,7 @@ class AdController: AdControllerType, Injectable {
 
     func close() {
         callback?(placementId, .adClosed)
-        logger.success("Event callback: adClosed")
+        logger.info("Event callback: adClosed for placement \(placementId)")
         adResponse = nil
         closed = true
     }
@@ -95,7 +95,7 @@ class AdController: AdControllerType, Injectable {
 
     func adShown() {
         callback?(placementId, .adShown)
-        logger.success("Event callback: adShown")
+        logger.info("Event callback: adShown for placement \(placementId)")
     }
 
     func adEnded() { callback?(placementId, .adEnded) }
@@ -137,10 +137,9 @@ class AdController: AdControllerType, Injectable {
     }
 
     private func onSuccess(_ response: AdResponse) {
-        logger.success("Ad load successful for \(response.placementId)")
         adResponse = response
         callback?(placementId, .adLoaded)
-        logger.success("Event callback: adLoaded")
+        logger.success("Event callback: adLoaded for \(response.placementId)")
     }
 
     private func onFailure(_ error: Error) {
@@ -175,7 +174,7 @@ class AdController: AdControllerType, Injectable {
         lastClickTime = currentTime
 
         callback?(placementId, .adClicked)
-        logger.success("Event callback: adClicked")
+        logger.success("Event callback: adClicked for \(placementId)")
 
         if adResponse.advert.creative.format == .video {
             eventRepository.videoClick(adResponse, completion: nil)

--- a/Pod/Classes/Video/VideoAd.swift
+++ b/Pod/Classes/Video/VideoAd.swift
@@ -12,7 +12,7 @@ public enum AdState {
     case hasAd(ad: SAAd)
 }
 
-@objc(SAVideoAd) public class VideoAd: NSObject {
+@objc(SAVideoAd) public class VideoAd: NSObject, Injectable {
 
     static var isTestingEnabled: Bool = Bool(truncating: NSNumber(value: SA_DEFAULT_TESTMODE))
     static var isParentalGateEnabled: Bool = Bool(truncating: NSNumber(value: SA_DEFAULT_PARENTALGATE))
@@ -31,6 +31,8 @@ public enum AdState {
     private static var ads = Dictionary<Int, AdState>()
 
     private static let events: SAEvents = SAEvents()
+    
+    private static var logger: LoggerType = dependencies.resolve(param: VideoAd.self)
 
     ////////////////////////////////////////////////////////////////////////////
     // Internal control methods
@@ -83,6 +85,7 @@ public enum AdState {
                 // reset video events
                 self.ads[placementId] = .hasAd(ad: ad)
                 self.callback?(placementId, .adLoaded)
+                logger.success("Event callback: adLoaded")
             }
 
         case .loading:
@@ -139,6 +142,7 @@ public enum AdState {
                 // reset video events
                 self.ads[placementId] = .hasAd(ad: ad)
                 self.callback?(placementId, .adLoaded)
+                logger.success("Event callback: adLoaded")
             }
 
         case .loading:

--- a/Pod/Classes/Video/VideoAd.swift
+++ b/Pod/Classes/Video/VideoAd.swift
@@ -85,14 +85,14 @@ public enum AdState {
                 // reset video events
                 self.ads[placementId] = .hasAd(ad: ad)
                 self.callback?(placementId, .adLoaded)
-                logger.success("Event callback: adLoaded")
+                logger.success("Event callback: adLoaded for placement \(placementId)")
             }
 
         case .loading:
             break
         case .hasAd:
             callback?(placementId, .adAlreadyLoaded)
-            logger.success("Event callback: adAlreadyLoaded")
+            logger.success("Event callback: adAlreadyLoaded for placement \(placementId)")
         }
     }
 
@@ -143,14 +143,14 @@ public enum AdState {
                 // reset video events
                 self.ads[placementId] = .hasAd(ad: ad)
                 self.callback?(placementId, .adLoaded)
-                logger.success("Event callback: adLoaded")
+                logger.success("Event callback: adLoaded for placement \(placementId)")
             }
 
         case .loading:
             break
         case .hasAd:
             callback?(placementId, .adAlreadyLoaded)
-            logger.success("Event callback: adAlreadyLoaded")
+            logger.success("Event callback: adAlreadyLoaded for placement \(placementId)")
         }
     }
 

--- a/Pod/Classes/Video/VideoAd.swift
+++ b/Pod/Classes/Video/VideoAd.swift
@@ -92,6 +92,7 @@ public enum AdState {
             break
         case .hasAd:
             callback?(placementId, .adAlreadyLoaded)
+            logger.success("Event callback: adAlreadyLoaded")
         }
     }
 
@@ -149,6 +150,7 @@ public enum AdState {
             break
         case .hasAd:
             callback?(placementId, .adAlreadyLoaded)
+            logger.success("Event callback: adAlreadyLoaded")
         }
     }
 

--- a/Pod/Classes/Video/VideoViewController.swift
+++ b/Pod/Classes/Video/VideoViewController.swift
@@ -197,7 +197,7 @@ import UIKit
         videoEvents.complete(player: videoPlayer, time: time, duration: duration)
         chrome.makeCloseButtonVisible()
         callback?(ad.placementId, .adEnded)
-        logger.success("Event callback: adEnded")
+        logger.info("Event callback: adEnded for placement \(ad.placementId)")
 
         if config.shouldCloseAtEnd {
             closeAction()
@@ -222,7 +222,7 @@ import UIKit
 
     private func clickAction() {
         callback?(ad.placementId, .adClicked)
-        logger.success("Event callback: adClicked")
+        logger.info("Event callback: adClicked for placement \(ad.placementId)")
         clickEvents.handleAdTap()
     }
 
@@ -232,7 +232,7 @@ import UIKit
         dismiss(animated: true) { [weak self] in
             if let placementId = self?.ad.placementId {
                 self?.callback?(placementId, .adClosed)
-                self?.logger.success("Event callback: adClosed")
+                self?.logger.info("Event callback: adClosed for placement \(placementId)")
             }
         }
     }

--- a/Pod/Classes/Video/VideoViewController.swift
+++ b/Pod/Classes/Video/VideoViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-@objc(SAVideoViewController) class VideoViewController: UIViewController, VideoPlayerDelegate, VideoEventsDelegate {
+@objc(SAVideoViewController) class VideoViewController: UIViewController, VideoPlayerDelegate, VideoEventsDelegate, Injectable {
 
     ////////////////////////////////////////////////////////////////////////////
     // SubViews
@@ -38,6 +38,8 @@ import UIKit
     private let clickEvents: VideoClick
 
     private var callback: AdEventCallback?
+    
+    private var logger: LoggerType = dependencies.resolve(param: VideoViewController.self)
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
@@ -195,6 +197,7 @@ import UIKit
         videoEvents.complete(player: videoPlayer, time: time, duration: duration)
         chrome.makeCloseButtonVisible()
         callback?(ad.placementId, .adEnded)
+        logger.success("Event callback: adEnded")
 
         if config.shouldCloseAtEnd {
             closeAction()
@@ -219,6 +222,7 @@ import UIKit
 
     private func clickAction() {
         callback?(ad.placementId, .adClicked)
+        logger.success("Event callback: adClicked")
         clickEvents.handleAdTap()
     }
 
@@ -228,6 +232,7 @@ import UIKit
         dismiss(animated: true) { [weak self] in
             if let placementId = self?.ad.placementId {
                 self?.callback?(placementId, .adClosed)
+                self?.logger.success("Event callback: adClosed")
             }
         }
     }


### PR DESCRIPTION
Adding debug logs for:
- adLoaded
- adShown
- adClicked
- adEnded
- adClosed
- adAlreadyLoaded

@gunhansancar:
**Please let me know if my use of logger anywhere isn't right** (my first time doing mobile development 🙂) - the logs are coming through correctly but unsure on if the logger library is being defined correctly, what log level to use, and if they need tags.

Video below showing logs being generated for all of the above, except `adAlreadyLoaded` - we may not need to test this in QA.

https://user-images.githubusercontent.com/48458132/152389448-752693a2-87a6-461f-b71f-2ae199c9f5f6.mov




