### PR TITLE
Aag 1592 event tracking calls

### DIFF
--- a/Pod/Classes/Common/DI/CommonModule.swift
+++ b/Pod/Classes/Common/DI/CommonModule.swift
@@ -75,7 +75,7 @@ struct CommonModule: DependencyModule {
             AdRepository(dataSource: container.resolve(), adQueryMaker: container.resolve(), adProcessor: container.resolve())
         }
         container.single(EventRepositoryType.self) { container, _ in
-            EventRepository(dataSource: container.resolve(), adQueryMaker: container.resolve())
+            EventRepository(dataSource: container.resolve(), adQueryMaker: container.resolve(), logger: container.resolve(param: EventRepository.self))
         }
         container.factory(VastEventRepositoryType.self) { container, param in
             guard let adResponse = param[0] as?  AdResponse else {

--- a/Pod/Classes/Common/Repositories/EventRepository.swift
+++ b/Pod/Classes/Common/Repositories/EventRepository.swift
@@ -20,21 +20,26 @@ protocol EventRepositoryType {
 class EventRepository: EventRepositoryType {
     private let dataSource: AwesomeAdsApiDataSourceType
     private let adQueryMaker: AdQueryMakerType
+    private let logger: LoggerType
 
-    init(dataSource: AwesomeAdsApiDataSourceType, adQueryMaker: AdQueryMakerType) {
+    init(dataSource: AwesomeAdsApiDataSourceType, adQueryMaker: AdQueryMakerType, logger: LoggerType) {
         self.dataSource = dataSource
         self.adQueryMaker = adQueryMaker
+        self.logger = logger
     }
 
     func impression(_ adResponse: AdResponse, completion: OnResult<Void>?) {
+        logger.info("Event Tracking: impression sent for \(adResponse.placementId)")
         dataSource.impression(query: adQueryMaker.makeImpressionQuery(adResponse), completion: completion)
     }
 
     func click(_ adResponse: AdResponse, completion: OnResult<Void>?) {
+        logger.info("Event Tracking: click sent for \(adResponse.placementId)")
         dataSource.click(query: adQueryMaker.makeClickQuery(adResponse), completion: completion)
     }
 
     func videoClick(_ adResponse: AdResponse, completion: OnResult<Void>?) {
+        logger.info("Event Tracking: video_click sent for \(adResponse.placementId)")
         dataSource.videoClick(query: adQueryMaker.makeVideoClickQuery(adResponse), completion: completion)
     }
 
@@ -55,10 +60,12 @@ class EventRepository: EventRepositoryType {
     }
 
     func viewableImpression(_ adResponse: AdResponse, completion: OnResult<Void>?) {
+        logger.info("Event Tracking: viewable_impression sent for \(adResponse.placementId)")
         customEvent(.viewableImpression, adResponse, completion: completion)
     }
 
     func dwellTime(_ adResponse: AdResponse, completion: OnResult<Void>?) {
+        logger.info("Event Tracking: dwell_time sent for \(adResponse.placementId)")
         customEvent(.dwellTime, adResponse, completion: completion)
     }
 

--- a/Pod/Classes/Common/Repositories/EventRepository.swift
+++ b/Pod/Classes/Common/Repositories/EventRepository.swift
@@ -39,7 +39,6 @@ class EventRepository: EventRepositoryType {
     }
 
     func videoClick(_ adResponse: AdResponse, completion: OnResult<Void>?) {
-        logger.info("Event Tracking: video_click sent for \(adResponse.placementId)")
         dataSource.videoClick(query: adQueryMaker.makeVideoClickQuery(adResponse), completion: completion)
     }
 
@@ -65,7 +64,6 @@ class EventRepository: EventRepositoryType {
     }
 
     func dwellTime(_ adResponse: AdResponse, completion: OnResult<Void>?) {
-        logger.info("Event Tracking: dwell_time sent for \(adResponse.placementId)")
         customEvent(.dwellTime, adResponse, completion: completion)
     }
 

--- a/Pod/Classes/Libs/SAEvents/SAEvents.m
+++ b/Pod/Classes/Libs/SAEvents/SAEvents.m
@@ -95,7 +95,7 @@
 
 - (void) triggerVASTImpressionEvent {
     if (_vastModule) {
-        NSLog(@"Event Tracking: vast_impression");
+        NSLog(@"Event Tracking: impression (video)");
         [_vastModule triggerVASTImpressionEvent: nil];
     }
 }
@@ -186,7 +186,7 @@
 - (BOOL) startMoatTrackingForVideoPlayer:(AVPlayer*) player
                                withLayer:(AVPlayerLayer*) layer
                                  andView:(UIView*) view {
-    NSLog(@"Event Tracking: moat_video_player");
+    NSLog(@"Event Tracking: moat (video_player)");
     return _moatModule ? [_moatModule startMoatTrackingForVideoPlayer:player withLayer:layer andView:view] : false;
 }
 

--- a/Pod/Classes/Libs/SAEvents/SAEvents.m
+++ b/Pod/Classes/Libs/SAEvents/SAEvents.m
@@ -95,6 +95,7 @@
 
 - (void) triggerVASTImpressionEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: vast_impression");
         [_vastModule triggerVASTImpressionEvent: nil];
     }
 }
@@ -113,30 +114,35 @@
 
 - (void) triggerVASTFirstQuartileEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: first_quartile");
         [_vastModule triggerVASTFirstQuartileEvent: nil];
     }
 }
 
 - (void) triggerVASTMidpointEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: midpoint");
         [_vastModule triggerVASTMidpointEvent: nil];
     }
 }
 
 - (void) triggerVASTThirdQuartileEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: third_quartile");
         [_vastModule triggerVASTThirdQuartileEvent: nil];
     }
 }
 
 - (void) triggerVASTCompleteEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: complete");
         [_vastModule triggerVASTCompleteEvent: nil];
     }
 }
 
 - (void) triggerVASTClickTrackingEvent {
     if (_vastModule) {
+        NSLog(@"Event Tracking: video_click");
         [_vastModule triggerVASTClickTrackingEvent: nil];
     }
 }
@@ -180,6 +186,7 @@
 - (BOOL) startMoatTrackingForVideoPlayer:(AVPlayer*) player
                                withLayer:(AVPlayerLayer*) layer
                                  andView:(UIView*) view {
+    NSLog(@"Event Tracking: moat_video_player");
     return _moatModule ? [_moatModule startMoatTrackingForVideoPlayer:player withLayer:layer andView:view] : false;
 }
 


### PR DESCRIPTION
Adding debug logs for event tracking:
- `moat` (video)
- `impression`
- `impression` (video)
- `viewable_impression`
- `click`
- `video_click`
- `first_quartile`
- `midpoint`
- `third_quartile`
- `complete`

Only event triggers I couldn't find were for `moat` (display) and `dwell_time`. I found trigger methods defined [here](https://github.com/SuperAwesomeLTD/sa-mobile-sdk-ios/blob/805fd130bc9ad88cc5cc2e0aa1aca8de6201efc8/Pod/Classes/Libs/SAEvents/SAEvents.m#L172) and [here](https://github.com/SuperAwesomeLTD/sa-mobile-sdk-ios/blob/3dbc505f75a2631a7bb263db34d9a2a5261b7988/Pod/Classes/Common/Repositories/EventRepository.swift#L61) respectively, but they aren't called anywhere in the code?