### PR TITLE
Bugfix: Add back SuperAwesomeUnityBumperOverrideName

### DIFF
--- a/Pod/Plugin/Unity/SAUnityBumperPage.mm
+++ b/Pod/Plugin/Unity/SAUnityBumperPage.mm
@@ -5,37 +5,18 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <SuperAwesome/SuperAwesome.h>
+#import <SuperAwesome/SABumperPage.h>
 
-/**
- * Generic method used to send messages back to unity
- *
- * @param unityName the name of the unity ad to send the message back to
- * @param data      a dictionary of data to send back
- */
-static inline void sendToUnity (NSString *unityName, NSDictionary *data) {
-    
-    const char *name = [unityName UTF8String];
-    NSString *payload = [data jsonCompactStringRepresentation];
-    const char *payloadUTF8 = [payload UTF8String];
-    UnitySendMessage (name, "nativeCallback", payloadUTF8);
-    
-}
-
-/**
- * Method that sends back ad data to Unity
- *
- * @param unityName     the name of the unity ad to send the message back to
- * @param placementId   placement id of the ad that called this
- * @param callback      callback method
- */
-static inline void unitySendAdCallback (NSString *unityName, NSInteger placementId, NSString *callback) {
-
-    NSDictionary *data = @{
-                           @"placementId": [NSString stringWithFormat:@"%ld", (long) placementId],
-                           @"type": [NSString stringWithFormat:@"sacallback_%@", callback]
-                           };
-    
-    sendToUnity(unityName, data);
-    
+extern "C" {
+    /**
+     * Unity to native iOS method that overrides the current version & sdk
+     * strings so that this will get reported correctly in the dashboard.
+     *
+     * @param nameString pointer to an array of chars containing the version
+     */
+    void SuperAwesomeUnityBumperOverrideName (const char *nameString) {
+        
+        NSString *name = [NSString stringWithUTF8String:nameString];
+        [SABumperPage overrideName: name];
+    }
 }


### PR DESCRIPTION
Adding back the removed `SuperAwesomeUnityBumperOverrideName` to the Unity iOS codes