### PR TITLE
Update Changelog with 8.3.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+8.3.0
+ - Fix showing KSF safe ad logos properly
+ - Fix Interstitial via KSF ads not loading
+ - Complete VPAID support
+ - Fix double encoding for event names
+ - Update internal dependencies
+
 8.0.8
  - Added Dwell Time
  - Cleaned up and updated dependencies across the board, including Admob and Mopub


### PR DESCRIPTION
We need to manually update the Changelog with release changes - we can add in the missing versions in a later effort, this is so we can provide visibility about 8.3.0.