### PR TITLE
fix(): The AwesomeVideoFullscreenPlayer would occasionally not expand to fill the fullscreen

### DIFF
--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoFullscreenPlayer.swift
@@ -66,6 +66,7 @@ public class AwesomeVideoFullscreenPlayer: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(player)
+        player.autoresizingMask = [.flexibleHeight, .flexibleWidth];
     }
 
     override public func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION

This PR fixes an issue where the `AwesomeVideoFullscreenPlayer` wouldn't fully fill the screen in some circumstances.