### PR TITLE
Added the ability to display the close button immediately and UI tests for the behaviour

### DIFF
--- a/Example/SuperAwesome/MainViewController.swift
+++ b/Example/SuperAwesome/MainViewController.swift
@@ -91,8 +91,8 @@ class MainViewController: UIViewController {
         VideoAd.enableParentalGate()
         VideoAd.enableBumperPage()
 
-        // Close button configured with no delay
-        VideoAd.enableCloseButtonNoDelay()
+        // Normal close button configuration
+        VideoAd.enableCloseButton()
     }
 
     func configuration2() {
@@ -105,8 +105,8 @@ class MainViewController: UIViewController {
         VideoAd.disableParentalGate()
         VideoAd.disableBumperPage()
 
-        // Normal close button configuration
-        VideoAd.enableCloseButton()
+        // Close button configured with no delay
+        VideoAd.enableCloseButtonNoDelay()
     }
 
     private func initUI() {

--- a/Example/SuperAwesome/MainViewController.swift
+++ b/Example/SuperAwesome/MainViewController.swift
@@ -90,6 +90,8 @@ class MainViewController: UIViewController {
 
         VideoAd.enableParentalGate()
         VideoAd.enableBumperPage()
+
+        // Close button configured with no delay
         VideoAd.enableCloseButtonNoDelay()
     }
 
@@ -102,7 +104,9 @@ class MainViewController: UIViewController {
 
         VideoAd.disableParentalGate()
         VideoAd.disableBumperPage()
-        VideoAd.disableCloseButtonNoDelay()
+
+        // Normal close button configuration
+        VideoAd.enableCloseButton()
     }
 
     private func initUI() {

--- a/Example/SuperAwesome/MainViewController.swift
+++ b/Example/SuperAwesome/MainViewController.swift
@@ -90,6 +90,7 @@ class MainViewController: UIViewController {
 
         VideoAd.enableParentalGate()
         VideoAd.enableBumperPage()
+        VideoAd.enableCloseButtonNoDelay()
     }
 
     func configuration2() {
@@ -101,6 +102,7 @@ class MainViewController: UIViewController {
 
         VideoAd.disableParentalGate()
         VideoAd.disableBumperPage()
+        VideoAd.disableCloseButtonNoDelay()
     }
 
     private func initUI() {
@@ -132,6 +134,7 @@ class MainViewController: UIViewController {
         let segment = UISegmentedControl(items: ["Enable checks", "Disable checks"])
         segment.addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
         segment.translatesAutoresizingMaskIntoConstraints = false
+        segment.accessibilityIdentifier = "configControl"
 
         view.addSubview(segment)
 
@@ -212,6 +215,7 @@ class MainViewController: UIViewController {
         stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.accessibilityIdentifier = "adsStackView"
 
         view.addSubview(stackView)
 

--- a/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
+++ b/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
@@ -62,11 +62,19 @@
 		C6C6AF4D27D7E37A00FFB5CA /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */; };
 		C6C6AF4E27D7E37A00FFB5CA /* HtmlFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */; };
 		C6C6AF4F27D7E37A00FFB5CA /* AdProcessorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */; };
+		CC6AE3D1284F906B002F7581 /* VideoAdUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */; };
 		CCDA7340283E56CB00A75542 /* AwesomeAdsTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		C6C6AEEB27D7D1D000FFB5CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1B76D22B1C91EEB1000AE8F3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1B76D2321C91EEB1000AE8F3;
+			remoteInfo = SuperAwesomeExample;
+		};
+		CC6AE3D4284F906B002F7581 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1B76D22B1C91EEB1000AE8F3 /* Project object */;
 			proxyType = 1;
@@ -143,6 +151,8 @@
 		C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HtmlFormatterTests.swift; sourceTree = "<group>"; };
 		C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdProcessorTest.swift; sourceTree = "<group>"; };
+		CC6AE3CE284F906B002F7581 /* SuperAwesomeExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SuperAwesomeExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdUITests.swift; sourceTree = "<group>"; };
 		CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwesomeAdsTargetTests.swift; sourceTree = "<group>"; };
 		D6B71C01F9DFB74D05E0B0FD /* Pods-SuperAwesomeExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuperAwesomeExample.debug.xcconfig"; path = "Target Support Files/Pods-SuperAwesomeExample/Pods-SuperAwesomeExample.debug.xcconfig"; sourceTree = "<group>"; };
 		D8F2154D326FE2F80967D14F /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -169,6 +179,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CC6AE3CB284F906B002F7581 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -178,6 +195,7 @@
 				C6535600245239270043115E /* SuperAwesomeExample.entitlements */,
 				1B76D2351C91EEB1000AE8F3 /* SuperAwesome */,
 				C6C6AEE827D7D1D000FFB5CA /* SuperAwesomeExampleTests */,
+				CC6AE3CF284F906B002F7581 /* SuperAwesomeExampleUITests */,
 				1B76D2341C91EEB1000AE8F3 /* Products */,
 				91259B494F3335F77596BCC1 /* Pods */,
 				63CB71636A495D6FBABE5223 /* Frameworks */,
@@ -189,6 +207,7 @@
 			children = (
 				1B76D2331C91EEB1000AE8F3 /* SuperAwesomeExample.app */,
 				C6C6AEE727D7D1D000FFB5CA /* SuperAwesomeExampleTests.xctest */,
+				CC6AE3CE284F906B002F7581 /* SuperAwesomeExampleUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -411,6 +430,14 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		CC6AE3CF284F906B002F7581 /* SuperAwesomeExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */,
+			);
+			path = SuperAwesomeExampleUITests;
+			sourceTree = "<group>";
+		};
 		CCDA733E283E569E00A75542 /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -461,13 +488,31 @@
 			productReference = C6C6AEE727D7D1D000FFB5CA /* SuperAwesomeExampleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		CC6AE3CD284F906B002F7581 /* SuperAwesomeExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC6AE3D8284F906B002F7581 /* Build configuration list for PBXNativeTarget "SuperAwesomeExampleUITests" */;
+			buildPhases = (
+				CC6AE3CA284F906B002F7581 /* Sources */,
+				CC6AE3CB284F906B002F7581 /* Frameworks */,
+				CC6AE3CC284F906B002F7581 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC6AE3D5284F906B002F7581 /* PBXTargetDependency */,
+			);
+			name = SuperAwesomeExampleUITests;
+			productName = SuperAwesomeExampleUITests;
+			productReference = CC6AE3CE284F906B002F7581 /* SuperAwesomeExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		1B76D22B1C91EEB1000AE8F3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -479,6 +524,12 @@
 					};
 					C6C6AEE627D7D1D000FFB5CA = {
 						CreatedOnToolsVersion = 13.2.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 1B76D2321C91EEB1000AE8F3;
+					};
+					CC6AE3CD284F906B002F7581 = {
+						CreatedOnToolsVersion = 13.3.1;
+						DevelopmentTeam = DCC9L689QJ;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 1B76D2321C91EEB1000AE8F3;
 					};
@@ -499,6 +550,7 @@
 			targets = (
 				1B76D2321C91EEB1000AE8F3 /* SuperAwesomeExample */,
 				C6C6AEE627D7D1D000FFB5CA /* SuperAwesomeExampleTests */,
+				CC6AE3CD284F906B002F7581 /* SuperAwesomeExampleUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -519,6 +571,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6C6AEFC27D7D39700FFB5CA /* fixtures_tests.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC6AE3CC284F906B002F7581 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -677,6 +736,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CC6AE3CA284F906B002F7581 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC6AE3D1284F906B002F7581 /* VideoAdUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -684,6 +751,11 @@
 			isa = PBXTargetDependency;
 			target = 1B76D2321C91EEB1000AE8F3 /* SuperAwesomeExample */;
 			targetProxy = C6C6AEEB27D7D1D000FFB5CA /* PBXContainerItemProxy */;
+		};
+		CC6AE3D5284F906B002F7581 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1B76D2321C91EEB1000AE8F3 /* SuperAwesomeExample */;
+			targetProxy = CC6AE3D4284F906B002F7581 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -936,6 +1008,62 @@
 			};
 			name = Release;
 		};
+		CC6AE3D6284F906B002F7581 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DCC9L689QJ;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.superawesome.SuperAwesomeExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SuperAwesomeExample;
+			};
+			name = Debug;
+		};
+		CC6AE3D7284F906B002F7581 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DCC9L689QJ;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.superawesome.SuperAwesomeExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SuperAwesomeExample;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -962,6 +1090,15 @@
 			buildConfigurations = (
 				C6C6AEEE27D7D1D000FFB5CA /* Debug */,
 				C6C6AEEF27D7D1D000FFB5CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC6AE3D8284F906B002F7581 /* Build configuration list for PBXNativeTarget "SuperAwesomeExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC6AE3D6284F906B002F7581 /* Debug */,
+				CC6AE3D7284F906B002F7581 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesome.xcscheme
+++ b/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesome.xcscheme
@@ -57,6 +57,16 @@
                ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC6AE3CD284F906B002F7581"
+               BuildableName = "SuperAwesomeExampleUITests.xctest"
+               BlueprintName = "SuperAwesomeExampleUITests"
+               ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesomeExample.xcscheme
+++ b/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesomeExample.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC6AE3CD284F906B002F7581"
+               BuildableName = "SuperAwesomeExampleUITests.xctest"
+               BlueprintName = "SuperAwesomeExampleUITests"
+               ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
+++ b/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
@@ -34,7 +34,7 @@ class VideoAdUITests: XCTestCase {
 
         // When
 
-        // The padlock is visible immediately so the close button should be visible at the same time
+        // The padlock is visible (it's visible immediately)
         let padlockResult = XCTWaiter.wait(for: [padlockExpectation], timeout: 5.0)
         XCTAssertEqual(padlockResult, .completed)
 
@@ -71,16 +71,16 @@ class VideoAdUITests: XCTestCase {
 
         // When
 
-        // The padlock is visible immediately so the close button should not be visible at the same time
+        // The padlock is visible (it's visible immediately)
         let padlockResult = XCTWaiter.wait(for: [padlockExpectation], timeout: 5.0)
         XCTAssertEqual(padlockResult, .completed)
 
+        // The close button is not initially visible
         XCTAssertFalse(app.buttons["closeButton"].exists)
 
         // Then
 
         // The close button is visible after a delay
-
         let closeButtonResult = XCTWaiter.wait(for: [closeButtonExpectation], timeout: 5.0)
 
         XCTAssertEqual(closeButtonResult, .completed)

--- a/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
+++ b/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
@@ -1,0 +1,88 @@
+//
+//  VideoAdUITests.swift
+//  SuperAwesomeExampleUITests
+//
+//  Created by Tom O'Rourke on 07/06/2022.
+//
+
+import XCTest
+
+class VideoAdUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCloseButtonAppearsWithNoDelay_WhenConfigured() throws {
+
+        let app = XCUIApplication()
+        app.launch()
+
+        // Given
+
+        // Close button appearing with no delay is configured via the SegmentControl
+        app.segmentedControls["configControl"].buttons.element(boundBy: 0).tap()
+
+        // Tap the video ad in the list
+        app.otherElements["adsStackView"].buttons.element(boundBy: 3).tap()
+
+        let padlockExpectation = expectation(
+            for: NSPredicate(format: "exists == true"),
+            evaluatedWith: app.buttons["padlock"],
+            handler: .none
+        )
+
+        // When
+
+        // The padlock is visible immediately so the close button should be visible at the same time
+        let padlockResult = XCTWaiter.wait(for: [padlockExpectation], timeout: 5.0)
+        XCTAssertEqual(padlockResult, .completed)
+
+        // Then
+
+        // The close button is visible
+        XCTAssertTrue(app.buttons["closeButton"].exists)
+    }
+
+    func testCloseButtonAppearsWithDelay_WhenConfigured() throws {
+
+        let app = XCUIApplication()
+        app.launch()
+
+        // Given
+
+        // Close button appearing with a delay is configured via the SegmentControl
+        app.segmentedControls["configControl"].buttons.element(boundBy: 1).tap()
+
+        // Tap the video ad in the list
+        app.otherElements["adsStackView"].buttons.element(boundBy: 3).tap()
+
+        let padlockExpectation = expectation(
+            for: NSPredicate(format: "exists == true"),
+            evaluatedWith: app.buttons["padlock"],
+            handler: .none
+        )
+
+        let closeButtonExpectation = expectation(
+            for: NSPredicate(format: "exists == true"),
+            evaluatedWith: app.buttons["closeButton"],
+            handler: .none
+        )
+
+        // When
+
+        // The padlock is visible immediately so the close button should not be visible at the same time
+        let padlockResult = XCTWaiter.wait(for: [padlockExpectation], timeout: 5.0)
+        XCTAssertEqual(padlockResult, .completed)
+
+        XCTAssertFalse(app.buttons["closeButton"].exists)
+
+        // Then
+
+        // The close button is visible after a delay
+
+        let closeButtonResult = XCTWaiter.wait(for: [closeButtonExpectation], timeout: 5.0)
+
+        XCTAssertEqual(closeButtonResult, .completed)
+    }
+}

--- a/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
+++ b/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
@@ -21,7 +21,7 @@ class VideoAdUITests: XCTestCase {
         // Given
 
         // Close button appearing with no delay is configured via the SegmentControl
-        app.segmentedControls["configControl"].buttons.element(boundBy: 0).tap()
+        app.segmentedControls["configControl"].buttons.element(boundBy: 1).tap()
 
         // Tap the video ad in the list
         app.otherElements["adsStackView"].buttons.element(boundBy: 3).tap()
@@ -52,7 +52,7 @@ class VideoAdUITests: XCTestCase {
         // Given
 
         // Close button appearing with a delay is configured via the SegmentControl
-        app.segmentedControls["configControl"].buttons.element(boundBy: 1).tap()
+        app.segmentedControls["configControl"].buttons.element(boundBy: 0).tap()
 
         // Tap the video ad in the list
         app.otherElements["adsStackView"].buttons.element(boundBy: 3).tap()

--- a/Pod/Classes/Common/Model/Constants.swift
+++ b/Pod/Classes/Common/Model/Constants.swift
@@ -11,8 +11,7 @@ struct Constants {
     static let defaultParentalGate = false
     static let defaultBumperPage = false
     static let defaultCloseAtEnd = true
-    static let defaultCloseButton = false
-    static let defaultCloseButtonNoDelay = false
+    static let defaultCloseButton: CloseButtonState = .hidden
     static let defaultSmallClick = false
     static let defaultOrientation = Orientation.any
     static let defaultEnvironment = Environment.production

--- a/Pod/Classes/Common/Model/Constants.swift
+++ b/Pod/Classes/Common/Model/Constants.swift
@@ -12,6 +12,7 @@ struct Constants {
     static let defaultBumperPage = false
     static let defaultCloseAtEnd = true
     static let defaultCloseButton = false
+    static let defaultCloseButtonNoDelay = false
     static let defaultSmallClick = false
     static let defaultOrientation = Orientation.any
     static let defaultEnvironment = Environment.production

--- a/Pod/Classes/Common/State/CloseButtonState.swift
+++ b/Pod/Classes/Common/State/CloseButtonState.swift
@@ -1,0 +1,12 @@
+//
+//  CloseButtonState.swift
+//  Alamofire
+//
+//  Created by Tom O'Rourke on 08/06/2022.
+//
+
+enum CloseButtonState {
+    case visibleWithDelay
+    case visibleImmediately
+    case hidden
+}

--- a/Pod/Classes/Common/State/CloseButtonState.swift
+++ b/Pod/Classes/Common/State/CloseButtonState.swift
@@ -1,6 +1,6 @@
 //
 //  CloseButtonState.swift
-//  Alamofire
+//  SuperAwesome
 //
 //  Created by Tom O'Rourke on 08/06/2022.
 //

--- a/Pod/Classes/UI/Common/AdConfig.swift
+++ b/Pod/Classes/UI/Common/AdConfig.swift
@@ -9,6 +9,7 @@ struct AdConfig {
     let showSmallClick: Bool
     let showSafeAdLogo: Bool
     let showCloseButton: Bool
+    let showCloseButtonNoDelay: Bool
     let shouldCloseAtEnd: Bool
     let isParentalGateEnabled: Bool
     let isBumperPageEnabled: Bool

--- a/Pod/Classes/UI/Common/AdConfig.swift
+++ b/Pod/Classes/UI/Common/AdConfig.swift
@@ -8,8 +8,7 @@
 struct AdConfig {
     let showSmallClick: Bool
     let showSafeAdLogo: Bool
-    let showCloseButton: Bool
-    let showCloseButtonNoDelay: Bool
+    let closeButtonState: CloseButtonState
     let shouldCloseAtEnd: Bool
     let isParentalGateEnabled: Bool
     let isBumperPageEnabled: Bool

--- a/Pod/Classes/UI/Video/AdSocialVideoPlayerControlsView.swift
+++ b/Pod/Classes/UI/Video/AdSocialVideoPlayerControlsView.swift
@@ -108,6 +108,7 @@ import UIKit
         clicker.addTarget(self, action: #selector(didTapOnUrl), for: .touchUpInside)
 
         closeButton = CloseButton()
+        closeButton.accessibilityIdentifier = "closeButton"
         closeButton.isHidden = true
         closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
         addSubview(closeButton)

--- a/Pod/Classes/UI/Video/ChromeComponents.swift
+++ b/Pod/Classes/UI/Video/ChromeComponents.swift
@@ -113,6 +113,7 @@ extension UILabel {
 
     init() {
         super.init(frame: CGRect.zero)
+        accessibilityIdentifier = "padlock"
         setImage(imageProvider.safeAdImage, for: .normal)
     }
 

--- a/Pod/Classes/UI/Video/VideoAd.swift
+++ b/Pod/Classes/UI/Video/VideoAd.swift
@@ -269,7 +269,8 @@ public class VideoAd: NSObject, Injectable {
     }
 
     /**
-     * Method that causes the close button to display immediately without a delay.
+     * Method that enables the close button to display immediately without a delay when showing the
+     * close button is enabled via enableCloseButton().
      * WARNING: this will allow users to close the ad before the viewable tracking event is fired
      * and should only be used if you explicitly want this behaviour over consistent tracking.
      */

--- a/Pod/Classes/UI/Video/VideoAd.swift
+++ b/Pod/Classes/UI/Video/VideoAd.swift
@@ -21,9 +21,7 @@ public class VideoAd: NSObject, Injectable {
     static var isParentalGateEnabled: Bool = Constants.defaultParentalGate
     static var isBumperPageEnabled: Bool = Constants.defaultBumperPage
     static var shouldAutomaticallyCloseAtEnd: Bool = Constants.defaultCloseAtEnd
-    static var shouldShowCloseButton: Bool = Constants.defaultCloseButton
-    static var shouldShowCloseButtonNoDelay: Bool = Constants.defaultCloseButtonNoDelay
-
+    static var closeButtonState: CloseButtonState = Constants.defaultCloseButton
     static var shouldShowSmallClickButton: Bool = Constants.defaultSmallClick
     static var orientation: Orientation = Constants.defaultOrientation
 
@@ -107,8 +105,7 @@ public class VideoAd: NSObject, Injectable {
         case .hasAd(let ad):
             let config = AdConfig(showSmallClick: shouldShowSmallClickButton,
                                   showSafeAdLogo: ad.advert.showPadlock,
-                                  showCloseButton: shouldShowCloseButton,
-                                  showCloseButtonNoDelay: shouldShowCloseButtonNoDelay,
+                                  closeButtonState: closeButtonState,
                                   shouldCloseAtEnd: shouldAutomaticallyCloseAtEnd,
                                   isParentalGateEnabled: isParentalGateEnabled,
                                   isBumperPageEnabled: isBumperPageEnabled,
@@ -255,7 +252,7 @@ public class VideoAd: NSObject, Injectable {
 
     @objc(setCloseButton:)
     public static func setCloseButton(_ close: Bool) {
-        shouldShowCloseButton = close
+        closeButtonState = close ? .visibleWithDelay : .hidden
     }
 
     @objc(enableCloseButton)
@@ -277,16 +274,7 @@ public class VideoAd: NSObject, Injectable {
 
     @objc(enableCloseButtonNoDelay)
     public static func enableCloseButtonNoDelay() {
-        shouldShowCloseButtonNoDelay = true
-    }
-
-    /**
-     * Method that disables the close button from showing without a delay.
-     */
-
-    @objc(disableCloseButtonNoDelay)
-    public static func disableCloseButtonNoDelay() {
-        shouldShowCloseButtonNoDelay = false
+        closeButtonState = .visibleImmediately
     }
 
     @objc(setSmallClick:)

--- a/Pod/Classes/UI/Video/VideoAd.swift
+++ b/Pod/Classes/UI/Video/VideoAd.swift
@@ -266,8 +266,7 @@ public class VideoAd: NSObject, Injectable {
     }
 
     /**
-     * Method that enables the close button to display immediately without a delay when showing the
-     * close button is enabled via enableCloseButton().
+     * Method that enables the close button to display immediately without a delay.
      * WARNING: this will allow users to close the ad before the viewable tracking event is fired
      * and should only be used if you explicitly want this behaviour over consistent tracking.
      */

--- a/Pod/Classes/UI/Video/VideoAd.swift
+++ b/Pod/Classes/UI/Video/VideoAd.swift
@@ -22,6 +22,7 @@ public class VideoAd: NSObject, Injectable {
     static var isBumperPageEnabled: Bool = Constants.defaultBumperPage
     static var shouldAutomaticallyCloseAtEnd: Bool = Constants.defaultCloseAtEnd
     static var shouldShowCloseButton: Bool = Constants.defaultCloseButton
+    static var shouldShowCloseButtonNoDelay: Bool = Constants.defaultCloseButtonNoDelay
 
     static var shouldShowSmallClickButton: Bool = Constants.defaultSmallClick
     static var orientation: Orientation = Constants.defaultOrientation
@@ -107,6 +108,7 @@ public class VideoAd: NSObject, Injectable {
             let config = AdConfig(showSmallClick: shouldShowSmallClickButton,
                                   showSafeAdLogo: ad.advert.showPadlock,
                                   showCloseButton: shouldShowCloseButton,
+                                  showCloseButtonNoDelay: shouldShowCloseButtonNoDelay,
                                   shouldCloseAtEnd: shouldAutomaticallyCloseAtEnd,
                                   isParentalGateEnabled: isParentalGateEnabled,
                                   isBumperPageEnabled: isBumperPageEnabled,
@@ -264,6 +266,26 @@ public class VideoAd: NSObject, Injectable {
     @objc(disableCloseButton)
     public static func disableCloseButton() {
         setCloseButton(false)
+    }
+
+    /**
+     * Method that causes the close button to display immediately without a delay.
+     * WARNING: this will allow users to close the ad before the viewable tracking event is fired
+     * and should only be used if you explicitly want this behaviour over consistent tracking.
+     */
+
+    @objc(enableCloseButtonNoDelay)
+    public static func enableCloseButtonNoDelay() {
+        shouldShowCloseButtonNoDelay = true
+    }
+
+    /**
+     * Method that disables the close button from showing without a delay.
+     */
+
+    @objc(disableCloseButtonNoDelay)
+    public static func disableCloseButtonNoDelay() {
+        shouldShowCloseButtonNoDelay = false
     }
 
     @objc(setSmallClick:)

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -78,7 +78,7 @@ import UIKit
         videoPlayer.setControlsView(controllerView: chrome)
         chrome.bind(toTheEdgesOf: videoPlayer)
 
-        if config.showCloseButtonNoDelay {
+        if config.showCloseButton && config.showCloseButtonNoDelay {
             chrome.makeCloseButtonVisible()
         }
 
@@ -133,7 +133,7 @@ extension VideoViewController: VideoEventsDelegate {
         controller.triggerViewableImpression()
         controller.triggerDwellTime()
 
-        if config.showCloseButton {
+        if config.showCloseButton && config.showCloseButtonNoDelay == false {
             chrome.makeCloseButtonVisible()
         }
     }

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -78,7 +78,7 @@ import UIKit
         videoPlayer.setControlsView(controllerView: chrome)
         chrome.bind(toTheEdgesOf: videoPlayer)
 
-        if config.showCloseButton && config.showCloseButtonNoDelay {
+        if config.closeButtonState == .visibleImmediately {
             chrome.makeCloseButtonVisible()
         }
 
@@ -133,7 +133,7 @@ extension VideoViewController: VideoEventsDelegate {
         controller.triggerViewableImpression()
         controller.triggerDwellTime()
 
-        if config.showCloseButton && config.showCloseButtonNoDelay == false {
+        if config.closeButtonState == .visibleWithDelay {
             chrome.makeCloseButtonVisible()
         }
     }

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -78,6 +78,10 @@ import UIKit
         videoPlayer.setControlsView(controllerView: chrome)
         chrome.bind(toTheEdgesOf: videoPlayer)
 
+        if config.showCloseButtonNoDelay {
+            chrome.makeCloseButtonVisible()
+        }
+
         // play ad
         if let url = controller.filePathUrl {
             control.play(url: url)


### PR DESCRIPTION
This PR adds the ability to display the close button immediately via the method: `enableCloseButtonNoDelay()`.
It seemed logical that `enableCloseButton` and `disableCloseButton` should still have the expected behaviour so both need to be set to remove the delay which I've documented. Once this is merged I'll need to update the SDK documentation too.

https://user-images.githubusercontent.com/30452349/172438798-359ea9d2-7967-41bd-9ccb-eee24155db59.mp4
