### PR TITLE
Fix/aag 2145 airplay issue constraints fix

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
   - Nimble (10.0.0)
-  - SuperAwesome (8.3.5):
+  - SuperAwesome (8.3.6):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -29,7 +29,7 @@ SPEC CHECKSUMS:
   Alamofire: 87bd8c952f9a4454320fce00d9cc3de57bcadaf5
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  SuperAwesome: 71888265e5f3a7d2a722e371993243c2b1f70168
+  SuperAwesome: b44a656e549f43def772b5ff1b52a36d2d58d09f
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: b2e141ff33d7b2ba0a68994472ccb6202a4eb48f

--- a/Pod/Classes/Common/Extensions/UIView+Extensions.swift
+++ b/Pod/Classes/Common/Extensions/UIView+Extensions.swift
@@ -56,14 +56,14 @@ extension UIView {
         }
     }
 
-    func bind(toTheEdgesOf otherView: UIView) {
+    func bind(toTheEdgesOf otherView: UIView, insets: UIEdgeInsets = .zero) {
         self.translatesAutoresizingMaskIntoConstraints = false
         let margins = otherView.layoutMarginsGuide
 
-        self.topAnchor.constraint(equalTo: margins.topAnchor, constant: 0.0).isActive = true
-        self.leadingAnchor.constraint(equalTo: margins.leadingAnchor, constant: 0.0).isActive = true
-        self.trailingAnchor.constraint(equalTo: margins.trailingAnchor, constant: 0.0).isActive = true
-        self.bottomAnchor.constraint(equalTo: margins.bottomAnchor, constant: -8.0).isActive = true
+        self.topAnchor.constraint(equalTo: margins.topAnchor, constant: insets.top).isActive = true
+        self.leadingAnchor.constraint(equalTo: margins.leadingAnchor, constant: insets.left).isActive = true
+        self.trailingAnchor.constraint(equalTo: margins.trailingAnchor, constant: insets.right).isActive = true
+        self.bottomAnchor.constraint(equalTo: margins.bottomAnchor, constant: insets.bottom).isActive = true
     }
 
     func bind(toTopRightOf otherView: UIView) {

--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoPlayer.swift
@@ -44,7 +44,6 @@ public class AwesomeVideoPlayer: UIView, VideoPlayer {
         self.controllerView?.set(delegate: self)
         guard let chrome = self.controllerView as? UIView else { return }
         addSubview(chrome)
-        chrome.translatesAutoresizingMaskIntoConstraints = false
         chrome.bind(toTheEdgesOf: self, insets: insets)
     }
 

--- a/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/AwesomeVideoPlayer.swift
@@ -37,27 +37,15 @@ public class AwesomeVideoPlayer: UIView, VideoPlayer {
         self.controller?.set(delegate: self)
     }
 
-    @objc(setConstrolsView:)
-    public func setControlsView(controllerView: VideoPlayerControlsView) {
+    @objc(setConstrolsView:insets:)
+    public func setControlsView(controllerView: VideoPlayerControlsView, insets: UIEdgeInsets = .zero) {
         (self.controllerView as? UIView)?.removeFromSuperview()
         self.controllerView = controllerView
         self.controllerView?.set(delegate: self)
         guard let chrome = self.controllerView as? UIView else { return }
         addSubview(chrome)
-    }
-
-    public override func updateConstraints() {
-        if !didSetUpConstraints {
-            didSetUpConstraints = true
-            if let chrome = self.controllerView as? UIView {
-                chrome.translatesAutoresizingMaskIntoConstraints = false
-                chrome.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-                chrome.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-                chrome.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
-                chrome.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-            }
-        }
-        super.updateConstraints()
+        chrome.translatesAutoresizingMaskIntoConstraints = false
+        chrome.bind(toTheEdgesOf: self, insets: insets)
     }
 
     public func destroy() {

--- a/Pod/Classes/Libs/SAVideoPlayer/VideoPlayer.swift
+++ b/Pod/Classes/Libs/SAVideoPlayer/VideoPlayer.swift
@@ -30,9 +30,10 @@ public protocol VideoPlayer: VideoPlayerControlsDelegate, VideoPlayerControlsVie
     /**
      * Sets the chrome control for the video player
      * @param chrome - an instance of an object that implements the ChromeControl protocol
+     * @param insets - the insets for the VideoPlayerControlsView
      */
-    @objc(setConstrolsView:)
-    func setControlsView(controllerView: VideoPlayerControlsView)
+    @objc(setConstrolsView:insets:)
+    func setControlsView(controllerView: VideoPlayerControlsView, insets: UIEdgeInsets)
 
     /**
      * Sets the state of the video to maximised

--- a/Pod/Classes/UI/Padding/Padding.swift
+++ b/Pod/Classes/UI/Padding/Padding.swift
@@ -8,17 +8,7 @@
 import UIKit
 
 internal enum Padding: CGFloat {
-    case xxsx = 1.0
-    case xxs = 2.0
-    case xsx = 3.0
-    case xs = 4.0
-    case sx = 6.0
     case s = 8.0
-    case sm = 12.0
-    case m = 16.0
-    case l = 32.0
-    case xl = 64.0
-    case xxl = 128.0
 
     public var value: CGFloat {
         rawValue

--- a/Pod/Classes/UI/Padding/Padding.swift
+++ b/Pod/Classes/UI/Padding/Padding.swift
@@ -1,0 +1,30 @@
+//
+//  Padding.swift
+//  Alamofire
+//
+//  Created by Tom O'Rourke on 27/06/2022.
+//
+
+import UIKit
+
+internal enum Padding: CGFloat {
+    case xxsx = 1.0
+    case xxs = 2.0
+    case xsx = 3.0
+    case xs = 4.0
+    case sx = 6.0
+    case s = 8.0
+    case sm = 12.0
+    case m = 16.0
+    case l = 32.0
+    case xl = 64.0
+    case xxl = 128.0
+
+    public var value: CGFloat {
+        rawValue
+    }
+
+    public var negative: CGFloat {
+        -1.0 as CGFloat * rawValue
+    }
+}

--- a/Pod/Classes/UI/Padding/Padding.swift
+++ b/Pod/Classes/UI/Padding/Padding.swift
@@ -1,6 +1,6 @@
 //
 //  Padding.swift
-//  Alamofire
+//  SuperAwesome
 //
 //  Created by Tom O'Rourke on 27/06/2022.
 //

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -17,8 +17,6 @@ import UIKit
     private let config: AdConfig
     private let control: VideoPlayerControls = VideoPlayerController()
     private let videoEvents: VideoEvents
-    private let padding = UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
-
     private var callback: AdEventCallback?
 
     init(adResponse: AdResponse, callback: AdEventCallback?, config: AdConfig) {
@@ -62,7 +60,10 @@ import UIKit
         videoPlayer.layoutMargins = .zero
         videoPlayer.setDelegate(delegate: self)
         view.addSubview(videoPlayer)
-        videoPlayer.bind(toTheEdgesOf: view, insets: padding)
+        videoPlayer.bind(
+            toTheEdgesOf: view,
+            insets: UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
+        )
 
         // setup chrome
         chrome = AdSocialVideoPlayerControlsView(smallClick: config.showSmallClick, showSafeAdLogo: config.showSafeAdLogo)
@@ -76,7 +77,10 @@ import UIKit
         chrome.setPadlockAction { [weak self] in
             self?.controller.handleSafeAdTap()
         }
-        videoPlayer.setControlsView(controllerView: chrome, insets: padding)
+        videoPlayer.setControlsView(
+            controllerView: chrome,
+            insets: UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
+        )
 
         if config.closeButtonState == .visibleImmediately {
             chrome.makeCloseButtonVisible()

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -62,7 +62,7 @@ import UIKit
         view.addSubview(videoPlayer)
         videoPlayer.bind(
             toTheEdgesOf: view,
-            insets: UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
+            insets: UIEdgeInsets(top: 0.0, left: 0.0, bottom: Padding.s.negative, right: 0.0)
         )
 
         // setup chrome
@@ -79,7 +79,7 @@ import UIKit
         }
         videoPlayer.setControlsView(
             controllerView: chrome,
-            insets: UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
+            insets: UIEdgeInsets(top: 0.0, left: 0.0, bottom: Padding.s.negative, right: 0.0)
         )
 
         if config.closeButtonState == .visibleImmediately {

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -17,6 +17,7 @@ import UIKit
     private let config: AdConfig
     private let control: VideoPlayerControls = VideoPlayerController()
     private let videoEvents: VideoEvents
+    private let padding = UIEdgeInsets(top: 0, left: 0, bottom: Padding.s.negative, right: 0)
 
     private var callback: AdEventCallback?
 
@@ -61,7 +62,7 @@ import UIKit
         videoPlayer.layoutMargins = .zero
         videoPlayer.setDelegate(delegate: self)
         view.addSubview(videoPlayer)
-        videoPlayer.bind(toTheEdgesOf: view)
+        videoPlayer.bind(toTheEdgesOf: view, insets: padding)
 
         // setup chrome
         chrome = AdSocialVideoPlayerControlsView(smallClick: config.showSmallClick, showSafeAdLogo: config.showSafeAdLogo)
@@ -75,8 +76,7 @@ import UIKit
         chrome.setPadlockAction { [weak self] in
             self?.controller.handleSafeAdTap()
         }
-        videoPlayer.setControlsView(controllerView: chrome)
-        chrome.bind(toTheEdgesOf: videoPlayer)
+        videoPlayer.setControlsView(controllerView: chrome, insets: padding)
 
         if config.closeButtonState == .visibleImmediately {
             chrome.makeCloseButtonVisible()


### PR DESCRIPTION
This PR fixes the constraint issues in the video player. I've aimed to keep the original constraint values the same but avoided having the `-8` in the `bind(toTheEdgesOf...` method as it seemed like it should be more generic. Originally `AwesomeVideoPlayer` had default insets of `0,0,0,0` but a constraint of `-8` was added to the bottom of the view that was passed in (named `chrome`) which caused the conflict. Instead I've changed it to add the constraints when setting the controls view with optional insets that default to `0, 0, 0, 0`.

Before: 

![ORIGINAL](https://user-images.githubusercontent.com/30452349/176155103-437602c8-1e1b-4f89-8c33-9bf30d164e1e.png)

After (consistent layout):

![Simulator Screen Shot - iPhone 11 Pro - 2022-06-27 at 22 00 49](https://user-images.githubusercontent.com/30452349/176155139-c14315c0-f93e-4161-aded-61e43e4cfa00.png)
