### PR TITLE
Added missing callback to the AdController

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
   - Nimble (10.0.0)
-  - SuperAwesome (8.3.6):
+  - SuperAwesome (8.3.7):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -29,7 +29,7 @@ SPEC CHECKSUMS:
   Alamofire: 87bd8c952f9a4454320fce00d9cc3de57bcadaf5
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  SuperAwesome: b44a656e549f43def772b5ff1b52a36d2d58d09f
+  SuperAwesome: 2b23966794feb9713de5998186e6cbfd48878e1d
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: b2e141ff33d7b2ba0a68994472ccb6202a4eb48f

--- a/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
+++ b/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
@@ -62,7 +62,6 @@
 		C6C6AF4D27D7E37A00FFB5CA /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */; };
 		C6C6AF4E27D7E37A00FFB5CA /* HtmlFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */; };
 		C6C6AF4F27D7E37A00FFB5CA /* AdProcessorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */; };
-		CC619C752881B46300D037C9 /* VideoAdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC619C742881B46300D037C9 /* VideoAdTests.swift */; };
 		CC6AE3D1284F906B002F7581 /* VideoAdUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */; };
 		CCDA7340283E56CB00A75542 /* AwesomeAdsTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */; };
 /* End PBXBuildFile section */
@@ -152,7 +151,6 @@
 		C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HtmlFormatterTests.swift; sourceTree = "<group>"; };
 		C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdProcessorTest.swift; sourceTree = "<group>"; };
-		CC619C742881B46300D037C9 /* VideoAdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdTests.swift; sourceTree = "<group>"; };
 		CC6AE3CE284F906B002F7581 /* SuperAwesomeExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SuperAwesomeExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdUITests.swift; sourceTree = "<group>"; };
 		CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwesomeAdsTargetTests.swift; sourceTree = "<group>"; };
@@ -301,7 +299,6 @@
 		C6895C4F27F4C79B009FAE1A /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				CC619C732881B45200D037C9 /* Ads */,
 				C6895C5027F4C7A1009FAE1A /* Common */,
 			);
 			path = UI;
@@ -431,14 +428,6 @@
 				C6895C5227F4CA38009FAE1A /* AdRepositoryMock.swift */,
 			);
 			path = Mocks;
-			sourceTree = "<group>";
-		};
-		CC619C732881B45200D037C9 /* Ads */ = {
-			isa = PBXGroup;
-			children = (
-				CC619C742881B46300D037C9 /* VideoAdTests.swift */,
-			);
-			path = Ads;
 			sourceTree = "<group>";
 		};
 		CC6AE3CF284F906B002F7581 /* SuperAwesomeExampleUITests */ = {
@@ -724,7 +713,6 @@
 				C6C6AF4F27D7E37A00FFB5CA /* AdProcessorTest.swift in Sources */,
 				C6C6AF2527D7D3DB00FFB5CA /* BundleMock.swift in Sources */,
 				CCDA7340283E56CB00A75542 /* AwesomeAdsTargetTests.swift in Sources */,
-				CC619C752881B46300D037C9 /* VideoAdTests.swift in Sources */,
 				C6C6AF2127D7D3DB00FFB5CA /* IdGeneratorMock.swift in Sources */,
 				C6C6AF1627D7D3DB00FFB5CA /* AdProcessorMock.swift in Sources */,
 				C6C6AF2827D7D3DB00FFB5CA /* SdkInfoMock.swift in Sources */,

--- a/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
+++ b/Example/SuperAwesomeExample.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		C6C6AF4D27D7E37A00FFB5CA /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */; };
 		C6C6AF4E27D7E37A00FFB5CA /* HtmlFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */; };
 		C6C6AF4F27D7E37A00FFB5CA /* AdProcessorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */; };
+		CC619C752881B46300D037C9 /* VideoAdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC619C742881B46300D037C9 /* VideoAdTests.swift */; };
 		CC6AE3D1284F906B002F7581 /* VideoAdUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */; };
 		CCDA7340283E56CB00A75542 /* AwesomeAdsTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */; };
 /* End PBXBuildFile section */
@@ -151,6 +152,7 @@
 		C6C6AF4127D7E37A00FFB5CA /* UserAgentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		C6C6AF4227D7E37A00FFB5CA /* HtmlFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HtmlFormatterTests.swift; sourceTree = "<group>"; };
 		C6C6AF4327D7E37A00FFB5CA /* AdProcessorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdProcessorTest.swift; sourceTree = "<group>"; };
+		CC619C742881B46300D037C9 /* VideoAdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdTests.swift; sourceTree = "<group>"; };
 		CC6AE3CE284F906B002F7581 /* SuperAwesomeExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SuperAwesomeExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC6AE3D0284F906B002F7581 /* VideoAdUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdUITests.swift; sourceTree = "<group>"; };
 		CCDA733F283E56CB00A75542 /* AwesomeAdsTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwesomeAdsTargetTests.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 		C6895C4F27F4C79B009FAE1A /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				CC619C732881B45200D037C9 /* Ads */,
 				C6895C5027F4C7A1009FAE1A /* Common */,
 			);
 			path = UI;
@@ -428,6 +431,14 @@
 				C6895C5227F4CA38009FAE1A /* AdRepositoryMock.swift */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		CC619C732881B45200D037C9 /* Ads */ = {
+			isa = PBXGroup;
+			children = (
+				CC619C742881B46300D037C9 /* VideoAdTests.swift */,
+			);
+			path = Ads;
 			sourceTree = "<group>";
 		};
 		CC6AE3CF284F906B002F7581 /* SuperAwesomeExampleUITests */ = {
@@ -713,6 +724,7 @@
 				C6C6AF4F27D7E37A00FFB5CA /* AdProcessorTest.swift in Sources */,
 				C6C6AF2527D7D3DB00FFB5CA /* BundleMock.swift in Sources */,
 				CCDA7340283E56CB00A75542 /* AwesomeAdsTargetTests.swift in Sources */,
+				CC619C752881B46300D037C9 /* VideoAdTests.swift in Sources */,
 				C6C6AF2127D7D3DB00FFB5CA /* IdGeneratorMock.swift in Sources */,
 				C6C6AF1627D7D3DB00FFB5CA /* AdProcessorMock.swift in Sources */,
 				C6C6AF2827D7D3DB00FFB5CA /* SdkInfoMock.swift in Sources */,

--- a/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
+++ b/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
@@ -12,10 +12,17 @@ import Nimble
 
 class AdControllerTests: XCTestCase {
     private var adRepository: AdRepositoryMock = AdRepositoryMock()
+    private let controller = AdController()
+    private var receivedEvent: AdEvent?
 
     override func setUp() {
         super.setUp()
         TestDependencies.register(adRepository: adRepository)
+        receivedEvent = nil
+
+        controller.callback = { [weak self] (placementId, event) in
+            self?.receivedEvent = event
+        }
     }
 
     private func showPadlockTest(showPadlock: Bool, ksfUrl: String?, expectedResult: Bool) {
@@ -24,13 +31,11 @@ class AdControllerTests: XCTestCase {
             AdResponse(123, MockFactory.makeAd(.tag, nil, nil, nil, showPadlock, ksfUrl))
         )
 
-        let controller = AdController()
-
         // When
         controller.load(123, MockFactory.makeAdRequest())
 
         // Then
-        expect(controller.showPadlock).to(equal(expectedResult))
+        XCTAssertEqual(controller.showPadlock, expectedResult)
     }
 
     func test_showPadlock() {
@@ -47,13 +52,6 @@ class AdControllerTests: XCTestCase {
             AdResponse(123, MockFactory.makeAd())
         )
 
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
         // When
         controller.load(123, MockFactory.makeAdRequest())
 
@@ -63,14 +61,9 @@ class AdControllerTests: XCTestCase {
 
     func testAdFailedToLoadCallback() {
         // Given
-        adRepository.response = .failure(MockFactory.makeError())
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
+        adRepository.response = .failure(
+            MockFactory.makeError()
+        )
 
         // When
         controller.load(123, MockFactory.makeAdRequest())
@@ -81,14 +74,6 @@ class AdControllerTests: XCTestCase {
 
     func testAdClosedCallback() {
         // Given
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
         controller.close()
 
         // Then
@@ -97,15 +82,6 @@ class AdControllerTests: XCTestCase {
 
     func testAdFailedToShowCallback() {
         // Given
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
         controller.adFailedToShow()
 
         // Then
@@ -114,15 +90,6 @@ class AdControllerTests: XCTestCase {
 
     func testAdEndedCallback() {
         // Given
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
         controller.adEnded()
 
         // Then
@@ -131,15 +98,6 @@ class AdControllerTests: XCTestCase {
 
     func testAdShownCallback() {
         // Given
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
         controller.adShown()
 
         // Then
@@ -148,15 +106,6 @@ class AdControllerTests: XCTestCase {
 
     func testAdClickedCallback() {
         // Given
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
         controller.adClicked()
 
         // Then

--- a/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
+++ b/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
@@ -61,7 +61,7 @@ class AdControllerTests: XCTestCase {
         XCTAssertEqual(receivedEvent, AdEvent.adLoaded)
     }
 
-    func testAdCFailedToLoadCallback() {
+    func testAdFailedToLoadCallback() {
         // Given
         adRepository.response = .failure(MockFactory.makeError())
 
@@ -95,7 +95,7 @@ class AdControllerTests: XCTestCase {
         XCTAssertEqual(receivedEvent, AdEvent.adClosed)
     }
 
-    func testAdCFailedToShowCallback() {
+    func testAdFailedToShowCallback() {
         // Given
 
         let controller = AdController()

--- a/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
+++ b/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
@@ -18,16 +18,6 @@ class AdControllerTests: XCTestCase {
         TestDependencies.register(adRepository: adRepository)
     }
 
-    private func configureAdResponseWithSuccess() {
-        adRepository.response = .success(
-            AdResponse(123, MockFactory.makeAd())
-        )
-    }
-
-    private func configureAdResponseWithError() {
-        adRepository.response = .failure(MockFactory.makeError())
-    }
-
     private func showPadlockTest(showPadlock: Bool, ksfUrl: String?, expectedResult: Bool) {
         // Given
         adRepository.response = .success(
@@ -53,7 +43,9 @@ class AdControllerTests: XCTestCase {
 
     func testAdLoadedCallback() {
         // Given
-        configureAdResponseWithSuccess()
+        adRepository.response = .success(
+            AdResponse(123, MockFactory.makeAd())
+        )
 
         let controller = AdController()
         var receivedEvent: AdEvent?
@@ -69,27 +61,9 @@ class AdControllerTests: XCTestCase {
         XCTAssertEqual(receivedEvent, AdEvent.adLoaded)
     }
 
-    func testAdClosedCallback() {
-        // Given
-        configureAdResponseWithSuccess()
-
-        let controller = AdController()
-        var receivedEvent: AdEvent?
-
-        controller.callback = { (placementId, event) in
-            receivedEvent = event
-        }
-
-        // When
-        controller.close()
-
-        // Then
-        XCTAssertEqual(receivedEvent, AdEvent.adClosed)
-    }
-
     func testAdCFailedToLoadCallback() {
         // Given
-        configureAdResponseWithError()
+        adRepository.response = .failure(MockFactory.makeError())
 
         let controller = AdController()
         var receivedEvent: AdEvent?
@@ -103,6 +77,22 @@ class AdControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(receivedEvent, AdEvent.adFailedToLoad)
+    }
+
+    func testAdClosedCallback() {
+        // Given
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.close()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adClosed)
     }
 
     func testAdCFailedToShowCallback() {

--- a/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
+++ b/Example/SuperAwesomeExampleTests/UI/Common/AdControllerTests.swift
@@ -18,6 +18,16 @@ class AdControllerTests: XCTestCase {
         TestDependencies.register(adRepository: adRepository)
     }
 
+    private func configureAdResponseWithSuccess() {
+        adRepository.response = .success(
+            AdResponse(123, MockFactory.makeAd())
+        )
+    }
+
+    private func configureAdResponseWithError() {
+        adRepository.response = .failure(MockFactory.makeError())
+    }
+
     private func showPadlockTest(showPadlock: Bool, ksfUrl: String?, expectedResult: Bool) {
         // Given
         adRepository.response = .success(
@@ -37,5 +47,129 @@ class AdControllerTests: XCTestCase {
         showPadlockTest(showPadlock: true, ksfUrl: "http", expectedResult: false)
         showPadlockTest(showPadlock: true, ksfUrl: nil, expectedResult: true)
         showPadlockTest(showPadlock: false, ksfUrl: "http", expectedResult: false)
+    }
+
+    // Callbacks
+
+    func testAdLoadedCallback() {
+        // Given
+        configureAdResponseWithSuccess()
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.load(123, MockFactory.makeAdRequest())
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adLoaded)
+    }
+
+    func testAdClosedCallback() {
+        // Given
+        configureAdResponseWithSuccess()
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.close()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adClosed)
+    }
+
+    func testAdCFailedToLoadCallback() {
+        // Given
+        configureAdResponseWithError()
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.load(123, MockFactory.makeAdRequest())
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adFailedToLoad)
+    }
+
+    func testAdCFailedToShowCallback() {
+        // Given
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.adFailedToShow()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adFailedToShow)
+    }
+
+    func testAdEndedCallback() {
+        // Given
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.adEnded()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adEnded)
+    }
+
+    func testAdShownCallback() {
+        // Given
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.adShown()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adShown)
+    }
+
+    func testAdClickedCallback() {
+        // Given
+
+        let controller = AdController()
+        var receivedEvent: AdEvent?
+
+        controller.callback = { (placementId, event) in
+            receivedEvent = event
+        }
+
+        // When
+        controller.adClicked()
+
+        // Then
+        XCTAssertEqual(receivedEvent, AdEvent.adClicked)
     }
 }

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -17,11 +17,9 @@ import UIKit
     private let config: AdConfig
     private let control: VideoPlayerControls = VideoPlayerController()
     private let videoEvents: VideoEvents
-    private var callback: AdEventCallback?
 
     init(adResponse: AdResponse, callback: AdEventCallback?, config: AdConfig) {
         self.config = config
-        self.callback = callback
         videoEvents = VideoEvents(adResponse)
         super.init(nibName: nil, bundle: nil)
         self.controller.adResponse = adResponse

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -25,6 +25,7 @@ import UIKit
         videoEvents = VideoEvents(adResponse)
         super.init(nibName: nil, bundle: nil)
         self.controller.adResponse = adResponse
+        self.controller.callback = callback
         self.controller.parentalGateEnabled = config.isParentalGateEnabled
         self.controller.bumperPageEnabled = config.isBumperPageEnabled
         videoEvents.delegate = self


### PR DESCRIPTION
This sets the callback property on the `AdController` for the `VideoViewController` to ensure that events are dispatched back to the `VideoAd` callback.

https://user-images.githubusercontent.com/30452349/179216388-afd352b3-6cfa-4cdd-a7ac-1ff603d7efc9.mov