### PR TITLE
fix(): SDK version was fetched from the bundle

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
   - Nimble (10.0.0)
-  - SuperAwesome (8.4.0):
+  - SuperAwesome (8.4.1):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -29,7 +29,7 @@ SPEC CHECKSUMS:
   Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  SuperAwesome: 73f42ac0ea71a78010109252ea58439e2f709b30
+  SuperAwesome: b5d2dad36bd96b99919e1fbff899588a53a6cfcb
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: b2e141ff33d7b2ba0a68994472ccb6202a4eb48f

--- a/Example/SuperAwesomeExampleTests/Common/Components/SdkInfoTests.swift
+++ b/Example/SuperAwesomeExampleTests/Common/Components/SdkInfoTests.swift
@@ -13,27 +13,25 @@ class SdkInfoTests: XCTestCase {
     func testSdkInfo() throws {
         // Given
         let mainBundle = BundleMock.make(name: "main Name", bundleId: "mainId", versionNumber: "mainVersion", localizations: ["xx"])
-        let sdkBundle = BundleMock.make(name: "sdkName", bundleId: "sdkId", versionNumber: "1.2.3", localizations: ["yy"])
         let locale = Locale(identifier: "en-US")
 
         // When
-        let sdk = SdkInfo(mainBundle: mainBundle, sdkBundle: sdkBundle, locale: locale, encoder: CustomEncoder())
+        let sdk = SdkInfo(mainBundle: mainBundle, locale: locale, encoder: CustomEncoder())
         SdkInfo.overrideVersion(nil, withPlatform: nil)
 
         // Then
         expect(sdk.bundle).to(equal("mainId"))
         expect(sdk.lang).to(equal("xx_US"))
         expect(sdk.name).to(equal("main%20Name"))
-        expect(sdk.version).to(equal("ios_1.2.3"))
-        expect(sdk.versionNumber).to(equal("1.2.3"))
+        expect(sdk.version).to(equal("ios_\(SDK_VERSION)"))
+        expect(sdk.versionNumber).to(equal("\(SDK_VERSION)"))
     }
 
     func test_overrideVersion() throws {
         // Given
         let mainBundle = BundleMock.make(name: "main Name", bundleId: "mainId", versionNumber: "mainVersion", localizations: ["xx"])
-        let sdkBundle = BundleMock.make(name: "sdkName", bundleId: "sdkId", versionNumber: "sdkVersion", localizations: ["yy"])
         let locale = Locale(identifier: "en-US")
-        let sdk = SdkInfo(mainBundle: mainBundle, sdkBundle: sdkBundle, locale: locale, encoder: CustomEncoder())
+        let sdk = SdkInfo(mainBundle: mainBundle, locale: locale, encoder: CustomEncoder())
 
         // When
         SdkInfo.overrideVersion("9.8.7", withPlatform: "unity")

--- a/Pod/Classes/Common/Components/SdkInfo.swift
+++ b/Pod/Classes/Common/Components/SdkInfo.swift
@@ -37,10 +37,8 @@ public class SdkInfo: NSObject, SdkInfoType {
     public var lang: String
     public var versionNumber: String
 
-    init(mainBundle: Bundle, sdkBundle: Bundle, locale: Locale, encoder: EncoderType) {
-        let platform = "ios"
-        self.versionNumber = sdkBundle.versionNumber ?? ""
-
+    init(mainBundle: Bundle, locale: Locale, encoder: EncoderType) {
+        self.versionNumber = SDK_VERSION
         self.bundle = mainBundle.bundleIdentifier ?? ""
         self.name = encoder.encodeUri(mainBundle.name)
 
@@ -57,7 +55,7 @@ public class SdkInfo: NSObject, SdkInfoType {
         self.pluginName = ""
         #endif
 
-        self.sdkVersion = "\(platform)_\(versionNumber)"
+        self.sdkVersion = "ios_\(versionNumber)"
     }
 
     public var version: String {

--- a/Pod/Classes/Common/DI/CommonModule.swift
+++ b/Pod/Classes/Common/DI/CommonModule.swift
@@ -32,7 +32,6 @@ struct CommonModule: DependencyModule {
         container.single(NumberGeneratorType.self) { _, _ in NumberGenerator() }
         container.single(SdkInfoType.self) { container, _ in
             SdkInfo(mainBundle: container.resolve(),
-                    sdkBundle: Bundle(for: DependencyContainer.self),
                     locale: Locale.current,
                     encoder: container.resolve())
         }

--- a/Pod/Classes/Common/Model/Version.swift
+++ b/Pod/Classes/Common/Model/Version.swift
@@ -1,0 +1,1 @@
+let SDK_VERSION = "8.4.1"

--- a/SuperAwesome.podspec
+++ b/SuperAwesome.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SuperAwesome'
-  s.version = '8.4.0'
+  s.version = File.read("Pod/Classes/Common/Model/Version.swift").split(" = ")[1].delete("\"")
   s.summary = 'SuperAwesome Mobile SDK for iOS'
   s.description = <<-DESC
                    The SuperAwesome Mobile SDK lets you to easily add COPPA compliant advertisements and other platform features, like user authentication and registration, to your apps. We try to make integration as easy as possible, so we provide all the necessary tools such as this guide, API documentation, screencasts and demo apps.


### PR DESCRIPTION
fix(): SDK version was fetched from the bundle which was a problem on non framework builds. Now the version is read in a file called `Version.swift` which is also parsed inside the `podspec` file as well. Therefore, the version information will be set in single place.