### PR TITLE
chore(): example app update for VPAID testing

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
   - Nimble (10.0.0)
-  - SuperAwesome (8.4.1):
+  - SuperAwesome (8.5.0):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -33,7 +33,7 @@ SPEC CHECKSUMS:
   DominantColor: 960c25e8d7eaf598bb5adae5c99a67a205ad3099
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  SuperAwesome: b5d2dad36bd96b99919e1fbff899588a53a6cfcb
+  SuperAwesome: 33a63378fd262864adb07fee26f70d813e435bd6
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: cfe343f4f28e16b34340085755eebcf3bd40ca97

--- a/Example/SuperAwesome/MainViewController.swift
+++ b/Example/SuperAwesome/MainViewController.swift
@@ -35,6 +35,11 @@ struct MultiIdRow: AdRow {
 }
 
 private let rows: [AdRow] = [
+    SingleIdRow(
+        type: .video,
+        name: "PopJam VPAID Video",
+        placementId: 93969
+    ),
     MultiIdRow(
         type: .banner,
         name: "Leaderboard MultiId",

--- a/Example/SuperAwesomeExampleUITests/InterstitialUITests.swift
+++ b/Example/SuperAwesomeExampleUITests/InterstitialUITests.swift
@@ -27,7 +27,7 @@ class InterstitialUITests: XCTestCase {
         )
 
         // When Tap the video ad in the list
-        app.otherElements["adsStackView"].buttons.element(boundBy: 1).tap()
+        app.otherElements["adsStackView"].buttons.element(boundBy: 2).tap()
 
         // Then the close button is visible
         let closeButtonResult = XCTWaiter.wait(for: [closeButtonExpectation], timeout: 5.0)
@@ -41,7 +41,7 @@ class InterstitialUITests: XCTestCase {
         app.launch()
 
         // Given
-        app.otherElements["adsStackView"].buttons.element(boundBy: 1).tap()
+        app.otherElements["adsStackView"].buttons.element(boundBy: 2).tap()
 
         let closeButtonExpectation = expectation(
             for: NSPredicate(format: "exists == true"),

--- a/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
+++ b/Example/SuperAwesomeExampleUITests/VideoAdUITests.swift
@@ -25,7 +25,7 @@ class VideoAdUITests: XCTestCase {
         app.segmentedControls["configControl"].buttons.element(boundBy: 1).tap()
 
         // Tap the video ad in the list
-        app.otherElements["adsStackView"].buttons.element(boundBy: 6).tap()
+        app.otherElements["adsStackView"].buttons.element(boundBy: 7).tap()
 
         let padlockExpectation = expectation(
             for: NSPredicate(format: "exists == true"),
@@ -56,7 +56,7 @@ class VideoAdUITests: XCTestCase {
         app.segmentedControls["configControl"].buttons.element(boundBy: 0).tap()
 
         // Tap the video ad in the list
-        app.otherElements["adsStackView"].buttons.element(boundBy: 6).tap()
+        app.otherElements["adsStackView"].buttons.element(boundBy: 7).tap()
 
         let padlockExpectation = expectation(
             for: NSPredicate(format: "exists == true"),
@@ -97,7 +97,7 @@ class VideoAdUITests: XCTestCase {
         app.segmentedControls["configControl"].buttons.element(boundBy: 0).tap()
 
         // Tap the non-ksf vpaid video ad in the list
-        app.otherElements["adsStackView"].buttons.element(boundBy: 5).tap()
+        app.otherElements["adsStackView"].buttons.element(boundBy: 6).tap()
 
         // When
 


### PR DESCRIPTION
This PR updates the example app with a new placement for Non-KSF VPAID testing