### PR TITLE
chore(): refactor admob integration code Part 1

### DIFF
--- a/Adapters/AdMob/Classes/SAAdMobBannerCustomEvent.m
+++ b/Adapters/AdMob/Classes/SAAdMobBannerCustomEvent.m
@@ -1,5 +1,4 @@
 #import "SAAdMobBannerCustomEvent.h"
-#import "SABannerAd.h"
 #import "SAAdMobExtras.h"
 
 // error domain
@@ -51,7 +50,6 @@
     
     if (params != nil) {
         [_bannerAd setTestMode:[[params objectForKey:kKEY_TEST] boolValue]];
-        [_bannerAd setConfiguration:[[params objectForKey:kKEY_CONFIGURATION] integerValue]];
         [_bannerAd setParentalGate:[[params objectForKey:kKEY_PARENTAL_GATE] boolValue]];
         [_bannerAd setBumperPage:[[params objectForKey:kKEY_BUMPER_PAGE] boolValue]];
         [_bannerAd setColor:[[params objectForKey:kKEY_TRANSPARENT] boolValue]];
@@ -61,7 +59,7 @@
     // Step 4. Add callbacks
     [_bannerAd setCallback:^(NSInteger placementId, SAEvent event) {
         switch (event) {
-            case adLoaded: {
+            case SAEventAdLoaded: {
                 
                 //
                 // send event
@@ -72,21 +70,21 @@
                 [weakSelf.bannerAd play];
                 break;
             }
-            case adEmpty: {
+            case SAEventAdEmpty: {
                 //
                 // send error in this case
                 NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
                 [weakSelf.delegate customEventBanner:weakSelf didFailAd:error];
                 break;
             }
-            case adFailedToLoad: {
+            case SAEventAdFailedToLoad: {
                 //
                 // send error in this case
                 NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
                 [weakSelf.delegate customEventBanner:weakSelf didFailAd:error];
                 break;
             }
-            case adClicked: {
+            case SAEventAdClicked: {
                 //
                 // send clicked and leave events
                 [weakSelf.delegate customEventBannerWasClicked:weakSelf];
@@ -95,11 +93,7 @@
             }
             //
             // non supported SA events
-            case adAlreadyLoaded:
-            case adShown:
-            case adFailedToShow:
-            case adEnded:
-            case adClosed:
+            default:
                 break;
         }
     }];

--- a/Adapters/AdMob/Classes/SAAdMobExtras.h
+++ b/Adapters/AdMob/Classes/SAAdMobExtras.h
@@ -1,13 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#import <SuperAwesome/AwesomeAds.h>
+@import SuperAwesome;
 
 @interface SAAdMobVideoExtra : NSObject <GADAdNetworkExtras>
 
 @property (nonatomic, assign) BOOL testEnabled;
-@property (nonatomic, assign) SAOrientation orientation;
-@property (nonatomic, assign) SAConfiguration configuration;
-@property (nonatomic, assign) SARTBStartDelay playback;
+@property (nonatomic, assign) Orientation orientation;
+@property (nonatomic, assign) enum StartDelay playback;
 @property (nonatomic, assign) BOOL parentalGateEnabled;
 @property (nonatomic, assign) BOOL bumperPageEnabled;
 @property (nonatomic, assign) BOOL closeButtonEnabled;
@@ -34,9 +33,8 @@
 
 @property (nonatomic, assign) BOOL trasparentEnabled;
 @property (nonatomic, assign) BOOL testEnabled;
-@property (nonatomic, assign) SAConfiguration configuration;
 @property (nonatomic, assign) BOOL parentalGateEnabled;
 @property (nonatomic, assign) BOOL bumperPageEnabled;
-@property (nonatomic, assign) SAOrientation orientation;
+@property (nonatomic, assign) Orientation orientation;
 
 @end

--- a/Adapters/AdMob/Classes/SAAdMobExtras.m
+++ b/Adapters/AdMob/Classes/SAAdMobExtras.m
@@ -4,14 +4,13 @@
 
 - (id) init {
     if (self = [super init]) {
-        _testEnabled = SA_DEFAULT_TESTMODE;
-        _configuration = SA_DEFAULT_CONFIGURATION;
-        _orientation = SA_DEFAULT_ORIENTATION;
-        _parentalGateEnabled = SA_DEFAULT_PARENTALGATE;
-        _bumperPageEnabled = SA_DEFAULT_BUMPERPAGE;
-        _closeButtonEnabled = SA_DEFAULT_CLOSEBUTTON;
-        _closeAtEndEnabled = SA_DEFAULT_CLOSEATEND;
-        _smallCLickEnabled = SA_DEFAULT_SMALLCLICK;
+        _testEnabled = false;
+        _orientation = OrientationAny;
+        _parentalGateEnabled = false;
+        _bumperPageEnabled = false;
+        _closeButtonEnabled = false;
+        _closeAtEndEnabled = true;
+        _smallCLickEnabled = false;
     }
     
     return self;
@@ -26,18 +25,16 @@
 @synthesize parentalGateEnabled = _parentalGateEnabled;
 @synthesize bumperPageEnabled = _bumperPageEnabled;
 @synthesize orientation = _orientation;
-@synthesize configuration = _configuration;
 
 - (id) init {
     _dict = [[NSMutableDictionary alloc] init];
     
     if (self = [super init]) {
-        _testEnabled = SA_DEFAULT_TESTMODE;
-        _configuration = SA_DEFAULT_CONFIGURATION;
-        _parentalGateEnabled = SA_DEFAULT_PARENTALGATE;
-        _bumperPageEnabled = SA_DEFAULT_BUMPERPAGE;
-        _orientation = SA_DEFAULT_ORIENTATION;
-        _trasparentEnabled = SA_DEFAULT_BGCOLOR;
+        _testEnabled = false;
+        _parentalGateEnabled = false;
+        _bumperPageEnabled = false;
+        _orientation = OrientationAny;
+        _trasparentEnabled = false;
     }
     
     return self;
@@ -68,11 +65,6 @@
     [_dict setObject:@(value) forKey:kKEY_TEST];
 }
 
-- (void) setConfiguration:(SAConfiguration)value {
-    _configuration = value;
-    [_dict setObject:@(value) forKey:kKEY_CONFIGURATION];
-}
-
 - (void) setParentalGateEnabled:(BOOL)value  {
     _parentalGateEnabled = value;
     [_dict setObject:@(value) forKey:kKEY_PARENTAL_GATE];
@@ -83,7 +75,7 @@
     [_dict setObject:@(value) forKey:kKEY_BUMPER_PAGE];
 }
 
-- (void) setOrientation:(SAOrientation)value {
+- (void) setOrientation:(Orientation)value {
     _orientation = value;
     [_dict setObject:@(value) forKey:kKEY_ORIENTATION];
 }

--- a/Adapters/AdMob/Classes/SAAdMobInterstitialCustomEvent.m
+++ b/Adapters/AdMob/Classes/SAAdMobInterstitialCustomEvent.m
@@ -55,40 +55,40 @@
     // Step 3. Add callbacks
     [SAInterstitialAd setCallback:^(NSInteger placementId, SAEvent event) {
         switch (event) {
-            case adLoaded: {
+            case SAEventAdLoaded: {
                 //
                 // send event to AdMob
                 [weakSelf.delegate customEventInterstitialDidReceiveAd:weakSelf];
                 break;
             }
-            case adEmpty: {
+            case SAEventAdEmpty: {
                 //
                 // send error info to AdMob
                 NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
                 [weakSelf.delegate customEventInterstitial:weakSelf didFailAd:error];
                 break;
             }
-            case adFailedToLoad: {
+            case SAEventAdFailedToLoad: {
                 //
                 // send error info to AdMob
                 NSError *error = [NSError errorWithDomain:kERROR_DOMAIN code:0 userInfo:nil];
                 [weakSelf.delegate customEventInterstitial:weakSelf didFailAd:error];
                 break;
             }
-            case adShown: {
+            case SAEventAdShown: {
                 //
                 // send event to AdMob
                 [weakSelf.delegate customEventInterstitialWillPresent:weakSelf];
                 break;
             }
-            case adClicked: {
+            case SAEventAdClicked: {
                 //
                 // send click & leve to AdMob
                 [weakSelf.delegate customEventInterstitialWasClicked:weakSelf];
                 [weakSelf.delegate customEventInterstitialWillLeaveApplication:weakSelf];
                 break;
             }
-            case adClosed: {
+            case SAEventAdClosed: {
                 //
                 // send will & did dismiss to AdMob
                 [weakSelf.delegate customEventInterstitialWillDismiss:weakSelf];
@@ -96,9 +96,7 @@
                 break;
             //
             // non supported SA events
-            case adAlreadyLoaded:
-            case adFailedToShow:
-            case adEnded:
+            default:
                 break;
             }
         }

--- a/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
+++ b/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
@@ -1,8 +1,7 @@
 #import "SAAdMobRewardedAd.h"
 #import "SAAdMobExtras.h"
-#import <SuperAwesome/SAVersion.h>
-#import <SuperAwesome/SuperAwesome-Swift.h>
 #include <stdatomic.h>
+@import SuperAwesome;
 
 #define kERROR_DOMAIN @"tv.superawesome.SAAdMobVideoMediationAdapter"
 
@@ -68,7 +67,6 @@
         [SAVideoAd setCloseButton:extras.closeButtonEnabled];
         [SAVideoAd setCloseAtEnd:extras.closeAtEndEnabled];
         [SAVideoAd setSmallClick:extras.smallCLickEnabled];
-        [SAVideoAd setConfiguration:extras.configuration];
         [SAVideoAd setPlaybackMode:extras.playback];
     }
     
@@ -90,35 +88,35 @@
     [SAVideoAd setCallback:^(NSInteger placementId, SAEvent event) {
         
         switch (event) {
-            case adLoaded: {
+            case SAEventAdLoaded: {
                 [weakSelf adLoaded];
                 break;
             }
-            case adEmpty: {
+            case SAEventAdEmpty: {
                 [weakSelf adFailed];
                 break;
             }
-            case adFailedToLoad: {
+            case SAEventAdFailedToLoad: {
                 [weakSelf adFailed];
                 break;
             }
-            case adShown: {
+            case SAEventAdShown: {
                 [weakSelf.delegate willPresentFullScreenView];
                 break;
             }
-            case adClicked: {
+            case SAEventAdClicked: {
                 [weakSelf.delegate reportClick];
                 [weakSelf.delegate willDismissFullScreenView];
                 break;
             }
-            case adClosed: {
+            case SAEventAdClosed: {
                 [weakSelf.delegate willDismissFullScreenView];
                 [weakSelf.delegate didDismissFullScreenView];
                 break;
             }
-            case adAlreadyLoaded:
-            case adFailedToShow:
-            case adEnded: {
+            case SAEventAdAlreadyLoaded:
+            case SAEventAdFailedToShow:
+            case SAEventAdEnded: {
                 GADAdReward *reward = [[GADAdReward alloc] initWithRewardType:@"Reward"
                                                                  rewardAmount:[[NSDecimalNumber alloc] initWithInt:1]];
                 

--- a/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.m
+++ b/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.m
@@ -1,8 +1,8 @@
 #import "SAAdMobVideoMediationAdapter.h"
 #import "SAAdMobExtras.h"
-#import <SuperAwesome/SAVersion.h>
 #import "SAAdMobRewardedAd.h"
 #include <stdatomic.h>
+@import SuperAwesome;
 
 #define kERROR_DOMAIN @"tv.superawesome.SAAdMobVideoMediationAdapter"
 
@@ -11,7 +11,7 @@
 }
 
 + (GADVersionNumber)adSDKVersion {
-    NSString *versionString = [SAVersion getSdkVersion];
+    NSString *versionString = [[AwesomeAds info] versionNumber];
     NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
     GADVersionNumber version = {0};
     if (versionComponents.count == 3) {
@@ -23,7 +23,7 @@
 }
 
 + (GADVersionNumber)version {
-    NSString *versionString = [NSString stringWithFormat:@"%@.0", [SAVersion getSdkVersion]];
+    NSString *versionString = [NSString stringWithFormat:@"%@.0", [[AwesomeAds info] versionNumber]];
     NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
     GADVersionNumber version = {0};
     if (versionComponents.count == 4) {
@@ -38,7 +38,7 @@
 }
 
 + (NSString *)adapterVersion {
-    return [SAVersion getSdkVersion];
+    return [[AwesomeAds info] versionNumber];
 }
 
 + (Class<GADAdNetworkExtras>)networkExtrasClass {

--- a/Adapters/AdMob/Example/Podfile.lock
+++ b/Adapters/AdMob/Example/Podfile.lock
@@ -1,83 +1,97 @@
 PODS:
-  - Google-Mobile-Ads-SDK (8.5.0):
-    - GoogleAppMeasurement (< 9.0, >= 7.0)
+  - Alamofire (5.6.4)
+  - Google-Mobile-Ads-SDK (9.14.0):
+    - GoogleAppMeasurement (< 11.0, >= 7.0)
     - GoogleUserMessagingPlatform (>= 1.1)
-  - GoogleAppMeasurement (8.0.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.0.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.0.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - GoogleUserMessagingPlatform (2.0.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.4.1):
+  - GoogleAppMeasurement (10.4.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.4.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/MethodSwizzler (~> 7.8)
+    - GoogleUtilities/Network (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (10.4.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.4.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/MethodSwizzler (~> 7.8)
+    - GoogleUtilities/Network (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.4.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/MethodSwizzler (~> 7.8)
+    - GoogleUtilities/Network (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleUserMessagingPlatform (2.0.1)
+  - GoogleUtilities/AppDelegateSwizzler (7.11.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.4.1):
-    - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.4.1):
+  - GoogleUtilities/Environment (7.11.0):
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.11.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.4.1):
+  - GoogleUtilities/MethodSwizzler (7.11.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.4.1):
+  - GoogleUtilities/Network (7.11.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.4.1)"
-  - GoogleUtilities/Reachability (7.4.1):
+  - "GoogleUtilities/NSData+zlib (7.11.0)"
+  - GoogleUtilities/Reachability (7.11.0):
     - GoogleUtilities/Logger
-  - nanopb (2.30908.0):
-    - nanopb/decode (= 2.30908.0)
-    - nanopb/encode (= 2.30908.0)
-  - nanopb/decode (2.30908.0)
-  - nanopb/encode (2.30908.0)
-  - PromisesObjC (1.2.12)
-  - SuperAwesome (7.2.19):
-    - SuperAwesome/Full (= 7.2.19)
-  - SuperAwesome/Base (7.2.19)
-  - SuperAwesome/Full (7.2.19):
-    - SuperAwesome/Base
-    - SuperAwesome/Moat
-  - SuperAwesome/Moat (7.2.19):
-    - SuperAwesome/Base
-  - SuperAwesomeAdMob (7.2.18):
+  - Moya (14.0.0):
+    - Moya/Core (= 14.0.0)
+  - Moya/Core (14.0.0):
+    - Alamofire (~> 5.0)
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
+  - PromisesObjC (2.1.1)
+  - SuperAwesome (8.5.0):
+    - Moya (~> 14.0)
+    - SwiftyXMLParser (= 5.6.0)
+  - SuperAwesomeAdMob (8.4.0-admob):
     - Google-Mobile-Ads-SDK
-    - SuperAwesome (~> 7.2)
+    - SuperAwesome (~> 8.5)
+  - SwiftyXMLParser (5.6.0)
 
 DEPENDENCIES:
   - SuperAwesomeAdMob (from `../../../`)
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
     - GoogleUserMessagingPlatform
     - GoogleUtilities
+    - Moya
     - nanopb
     - PromisesObjC
     - SuperAwesome
+    - SwiftyXMLParser
 
 EXTERNAL SOURCES:
   SuperAwesomeAdMob:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: 6f5c41bf73db1656e5b203ba9c31e3d0899a128d
-  GoogleAppMeasurement: c6bbc9753d046b5456dd4f940057fbad2c28419e
-  GoogleUserMessagingPlatform: ab890ce5f6620f293a21b6bdd82e416a2c73aeca
-  GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
-  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  SuperAwesome: feccc30331422c0ccc9b303b577d1e03014be492
-  SuperAwesomeAdMob: ca29521c33fa3faded384cc6f44fe7d7f6e6dee9
+  Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
+  Google-Mobile-Ads-SDK: 4fe6304b771f8467d29978cb790ec1e56e646946
+  GoogleAppMeasurement: 173fa22ce7d62c29332568e853b39b2525a0e584
+  GoogleUserMessagingPlatform: 5f8b30daf181805317b6b985bb51c1ff3beca054
+  GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
+  Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  SuperAwesome: 33a63378fd262864adb07fee26f70d813e435bd6
+  SuperAwesomeAdMob: 4db152501592f122209b87218aac196d98ce7425
+  SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: d9f17782073701152863b71254b43ce6dd7582e8
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3

--- a/Adapters/AdMob/Example/SuperAwesomeAdMob.xcodeproj/project.pbxproj
+++ b/Adapters/AdMob/Example/SuperAwesomeAdMob.xcodeproj/project.pbxproj
@@ -308,16 +308,22 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SuperAwesomeAdMob_Example/Pods-SuperAwesomeAdMob_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
+				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
 				"${BUILT_PRODUCTS_DIR}/SuperAwesome/SuperAwesome.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftyXMLParser/SwiftyXMLParser.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SuperAwesome.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyXMLParser.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Adapters/AdMob/Example/SuperAwesomeAdMob/AdMobViewController.swift
+++ b/Adapters/AdMob/Example/SuperAwesomeAdMob/AdMobViewController.swift
@@ -45,7 +45,7 @@ class AdMobViewController: UIViewController {
         let request = GADRequest()
         request.register(extras)
 
-        bannerView = GADBannerView(adSize: kGADAdSizeBanner)
+        bannerView = GADBannerView(adSize: GADAdSizeBanner)
         bannerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bannerView)
         view.addConstraints([

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
-  - Alamofire (5.6.2)
+  - Alamofire (5.6.4)
   - DominantColor (0.2.0)
-  - Firebase/AnalyticsWithoutAdIdSupport (9.3.0):
+  - Firebase/AnalyticsWithoutAdIdSupport (9.6.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics/WithoutAdIdSupport (~> 9.3.0)
-  - Firebase/CoreOnly (9.3.0):
-    - FirebaseCore (= 9.3.0)
-  - FirebaseAnalytics/WithoutAdIdSupport (9.3.0):
+    - FirebaseAnalytics/WithoutAdIdSupport (~> 9.6.0)
+  - Firebase/CoreOnly (9.6.0):
+    - FirebaseCore (= 9.6.0)
+  - FirebaseAnalytics/WithoutAdIdSupport (9.6.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.3.0)
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.6.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (9.3.0):
+  - FirebaseCore (9.6.0):
     - FirebaseCoreDiagnostics (~> 9.0)
     - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.3.0):
+  - FirebaseCoreDiagnostics (9.6.0):
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
@@ -33,40 +33,40 @@ PODS:
   - FirebaseDatabaseSwift (9.6.0):
     - FirebaseDatabase (~> 9.0)
     - FirebaseSharedSwift (~> 9.0)
-  - FirebaseInstallations (9.3.0):
+  - FirebaseInstallations (9.6.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (~> 2.1)
   - FirebaseSharedSwift (9.6.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (9.3.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (9.6.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.1.4):
+  - GoogleDataTransport (9.2.0):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.11.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.7.0):
+  - GoogleUtilities/Environment (7.11.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.7.0):
+  - GoogleUtilities/Logger (7.11.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.7.0):
+  - GoogleUtilities/MethodSwizzler (7.11.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.7.0):
+  - GoogleUtilities/Network (7.11.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.7.0)"
-  - GoogleUtilities/Reachability (7.7.0):
+  - "GoogleUtilities/NSData+zlib (7.11.0)"
+  - GoogleUtilities/Reachability (7.11.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.7.0):
+  - GoogleUtilities/UserDefaults (7.11.0):
     - GoogleUtilities/Logger
   - leveldb-library (1.22.1)
   - Moya (14.0.0):
@@ -120,26 +120,26 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
+  Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
   DominantColor: 960c25e8d7eaf598bb5adae5c99a67a205ad3099
-  Firebase: ef75abb1cdbc746d5a38f4e26c422c807b189b8c
-  FirebaseAnalytics: bf46f5163f44097ce2c789de0b3e6f87f1da834a
-  FirebaseCore: c088995ece701a021a48a1348ea0174877de2a6a
-  FirebaseCoreDiagnostics: 060eb57cc56dfaf40b1b1b5874a5c17c41ce79f8
+  Firebase: 5ae8b7cf8efce559a653aef0ad95bab3f427c351
+  FirebaseAnalytics: 89ad762c6c3852a685794174757e2c60a36b6a82
+  FirebaseCore: 2082fffcd855f95f883c0a1641133eb9bbe76d40
+  FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
   FirebaseDatabase: 3de19e533a73d45e25917b46aafe1dd344ec8119
   FirebaseDatabaseSwift: 3ed949f60e9beaa8eff9842b5de5f5e330649cc3
-  FirebaseInstallations: 54b40022cb06e462740c9f2b9fbe38b5e78a825a
+  FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
   FirebaseSharedSwift: 2269c2ddc7a5efb7fb5f3f3177e790613b52dfda
-  GoogleAppMeasurement: b907bdad775b6975a8108762345b2cfbf1a93c37
-  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
-  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
+  GoogleAppMeasurement: 6de2b1a69e4326eb82ee05d138f6a5cb7311bcb1
+  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
+  GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  SuperAwesome: 6c19aaffe96c114e524156660da1f345bddca184
+  SuperAwesome: dcacdc306c556d887d9111660b1a6c162113491b
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: cdfba0552c4704342023f282cacf6709606fe00b

--- a/SAAdMobAdapter.swift
+++ b/SAAdMobAdapter.swift
@@ -22,8 +22,8 @@ class SAAdMobAdapter: NSObject, GADMediationAdapter {
         let versionComponents = versionNumber.components(separatedBy: ".")
         var version = GADVersionNumber()
         if versionComponents.count == 3 {
-          version.majorVersion = Int(versionComponents[0]) ?? 0
-          version.minorVersion = Int(versionComponents[1]) ?? 0
+            version.majorVersion = Int(versionComponents[0]) ?? 0
+            version.minorVersion = Int(versionComponents[1]) ?? 0
             version.patchVersion = (Int(versionComponents[2]) ?? 0) * 100
         }
         return version
@@ -32,18 +32,19 @@ class SAAdMobAdapter: NSObject, GADMediationAdapter {
     static func adSDKVersion() -> GADVersionNumber {
         let versionNumber = AwesomeAds.info()?.versionNumber ?? ""
         let versionComponents = versionNumber.components(separatedBy: ".")
-
+        
         if versionComponents.count >= 3 {
-          let majorVersion = Int(versionComponents[0]) ?? 0
-          let minorVersion = Int(versionComponents[1]) ?? 0
-          let patchVersion = Int(versionComponents[2]) ?? 0
-
-          return GADVersionNumber(
-            majorVersion: majorVersion, minorVersion: minorVersion, patchVersion: patchVersion)
+            let majorVersion = Int(versionComponents[0]) ?? 0
+            let minorVersion = Int(versionComponents[1]) ?? 0
+            let patchVersion = Int(versionComponents[2]) ?? 0
+            
+            return GADVersionNumber(majorVersion: majorVersion,
+                                    minorVersion: minorVersion,
+                                    patchVersion: patchVersion)
         }
-
+        
         return GADVersionNumber()
-      }
+    }
     
     static func networkExtrasClass() -> GADAdNetworkExtras.Type? {
         return nil

--- a/SAAdMobAdapter.swift
+++ b/SAAdMobAdapter.swift
@@ -47,7 +47,7 @@ class SAAdMobAdapter: NSObject, GADMediationAdapter {
     }
     
     static func networkExtrasClass() -> GADAdNetworkExtras.Type? {
-        return nil
+       nil
     }
     
     func loadBanner(for adConfiguration: GADMediationBannerAdConfiguration, completionHandler: @escaping GADMediationBannerLoadCompletionHandler) {

--- a/SAAdMobAdapter.swift
+++ b/SAAdMobAdapter.swift
@@ -56,10 +56,10 @@ class SAAdMobAdapter: NSObject, GADMediationAdapter {
     }
     
     func loadInterstitial(for adConfiguration: GADMediationInterstitialAdConfiguration, completionHandler: @escaping GADMediationInterstitialLoadCompletionHandler) {
-        
+        // TODO: Load interstitial
     }
     
     func loadRewardedAd(for adConfiguration: GADMediationRewardedAdConfiguration, completionHandler: @escaping GADMediationRewardedLoadCompletionHandler) {
-        
+        // TODO: Load video ad
     }
 }

--- a/SAAdMobAdapter.swift
+++ b/SAAdMobAdapter.swift
@@ -1,0 +1,64 @@
+//
+//  SAAdMobAdapter.swift
+//  SuperAwesomeAdMob
+//
+//  Created by Gunhan Sancar on 19/01/2023.
+//
+
+import GoogleMobileAds
+import SuperAwesome
+
+@objc(SAAdMobAdapter)
+class SAAdMobAdapter: NSObject, GADMediationAdapter {
+    
+    fileprivate var bannerAd: SAAdMobBannerAd? = nil
+    
+    required override init() {
+        super.init()
+    }
+    
+    static func adapterVersion() -> GADVersionNumber {
+        let versionNumber = AwesomeAds.info()?.versionNumber ?? ""
+        let versionComponents = versionNumber.components(separatedBy: ".")
+        var version = GADVersionNumber()
+        if versionComponents.count == 3 {
+          version.majorVersion = Int(versionComponents[0]) ?? 0
+          version.minorVersion = Int(versionComponents[1]) ?? 0
+            version.patchVersion = (Int(versionComponents[2]) ?? 0) * 100
+        }
+        return version
+    }
+    
+    static func adSDKVersion() -> GADVersionNumber {
+        let versionNumber = AwesomeAds.info()?.versionNumber ?? ""
+        let versionComponents = versionNumber.components(separatedBy: ".")
+
+        if versionComponents.count >= 3 {
+          let majorVersion = Int(versionComponents[0]) ?? 0
+          let minorVersion = Int(versionComponents[1]) ?? 0
+          let patchVersion = Int(versionComponents[2]) ?? 0
+
+          return GADVersionNumber(
+            majorVersion: majorVersion, minorVersion: minorVersion, patchVersion: patchVersion)
+        }
+
+        return GADVersionNumber()
+      }
+    
+    static func networkExtrasClass() -> GADAdNetworkExtras.Type? {
+        return nil
+    }
+    
+    func loadBanner(for adConfiguration: GADMediationBannerAdConfiguration, completionHandler: @escaping GADMediationBannerLoadCompletionHandler) {
+        bannerAd = SAAdMobBannerAd()
+        bannerAd?.loadBanner(for: adConfiguration, completionHandler: completionHandler)
+    }
+    
+    func loadInterstitial(for adConfiguration: GADMediationInterstitialAdConfiguration, completionHandler: @escaping GADMediationInterstitialLoadCompletionHandler) {
+        
+    }
+    
+    func loadRewardedAd(for adConfiguration: GADMediationRewardedAdConfiguration, completionHandler: @escaping GADMediationRewardedLoadCompletionHandler) {
+        
+    }
+}

--- a/SAAdMobBannerAd.swift
+++ b/SAAdMobBannerAd.swift
@@ -31,14 +31,13 @@ class SAAdMobBannerAd: NSObject, GADMediationBannerAd {
         for adConfiguration: GADMediationBannerAdConfiguration,
         completionHandler: @escaping GADMediationBannerLoadCompletionHandler
     ) {
-        guard let placementString = adConfiguration.credentials.settings["parameter"] as? String, let placementId = Int(placementString) else {
-            return
-        }
+        let parameter = adConfiguration.credentials.settings["parameter"] as? String ?? ""
+        let placementId = Int(parameter) ?? 0
         let adSize = adConfiguration.adSize
-        print(adSize.size)
+        
         bannerAd = BannerView(frame: CGRect(x: 0, y: 0, width: adSize.size.width, height: adSize.size.height))
-        bannerAd?.setCallback({ placementId, event in
-            self.onEvent(placementId, event)
+        bannerAd?.setCallback({ [weak self] placementId, event in
+            self?.onEvent(placementId, event)
         })
         self.completionHandler = completionHandler
         bannerAd?.load(placementId)

--- a/SAAdMobBannerAd.swift
+++ b/SAAdMobBannerAd.swift
@@ -1,0 +1,79 @@
+//
+//  SAAdMobBannerAd.swift
+//  SuperAwesomeAdMob
+//
+//  Created by Gunhan Sancar on 19/01/2023.
+//
+
+import GoogleMobileAds
+import SuperAwesome
+
+@objc(SAAdMobBannerAd)
+class SAAdMobBannerAd: NSObject, GADMediationBannerAd {
+    var view: UIView {
+        return bannerAd ?? UIView()
+    }
+    
+    required override init() {
+        super.init()
+    }
+    
+    /// AwesomeAds banner ad.
+    var bannerAd: BannerView?
+    
+    /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
+    var delegate: GADMediationBannerAdEventDelegate?
+    
+    /// Completion handler called after ad load
+    var completionHandler: GADMediationBannerLoadCompletionHandler?
+    
+    func loadBanner(
+        for adConfiguration: GADMediationBannerAdConfiguration,
+        completionHandler: @escaping GADMediationBannerLoadCompletionHandler
+    ) {
+        guard let placementString = adConfiguration.credentials.settings["parameter"] as? String, let placementId = Int(placementString) else {
+            return
+        }
+        let adSize = adConfiguration.adSize
+        print(adSize.size)
+        bannerAd = BannerView(frame: CGRect(x: 0, y: 0, width: adSize.size.width, height: adSize.size.height))
+        bannerAd?.setCallback({ placementId, event in
+            self.onEvent(placementId, event)
+        })
+        self.completionHandler = completionHandler
+        bannerAd?.load(placementId)
+    }
+    
+    private func onEvent(_ placementId: Int, _ event: AdEvent) {
+        switch event {
+        case .adLoaded: adLoaded()
+        case .adEmpty: adError(message: "Ad is empty")
+        case .adFailedToLoad: adError(message: "Ad failed to laod")
+        case .adClicked: adClicked()
+        default:
+            break
+        }
+    }
+    
+    private func adLoaded() {
+        if let handler = completionHandler {
+            delegate = handler(self, nil)
+        }
+        bannerAd?.play()
+    }
+    
+    private func adError(message: String) {
+        let error = NSError(domain: "tv.superawesome.SAAdMobBannerAd",
+                            code: 0,
+                            userInfo: [ NSLocalizedDescriptionKey: message])
+        
+        if let handler = completionHandler {
+            delegate = handler(nil, error)
+        }
+    }
+    
+    private func adClicked() {
+        delegate?.reportClick()
+        delegate?.willPresentFullScreenView()
+    }
+}

--- a/SAAdMobBannerAd.swift
+++ b/SAAdMobBannerAd.swift
@@ -11,11 +11,7 @@ import SuperAwesome
 @objc(SAAdMobBannerAd)
 class SAAdMobBannerAd: NSObject, GADMediationBannerAd {
     var view: UIView {
-        return bannerAd ?? UIView()
-    }
-    
-    required override init() {
-        super.init()
+        bannerAd ?? UIView()
     }
     
     /// AwesomeAds banner ad.
@@ -35,7 +31,7 @@ class SAAdMobBannerAd: NSObject, GADMediationBannerAd {
         let placementId = Int(parameter) ?? 0
         let adSize = adConfiguration.adSize
         
-        bannerAd = BannerView(frame: CGRect(x: 0, y: 0, width: adSize.size.width, height: adSize.size.height))
+        bannerAd = BannerView(frame: CGRect(x: 0.0, y: 0.0, width: adSize.size.width, height: adSize.size.height))
         bannerAd?.setCallback({ [weak self] placementId, event in
             self?.onEvent(placementId, event)
         })
@@ -62,7 +58,7 @@ class SAAdMobBannerAd: NSObject, GADMediationBannerAd {
     }
     
     private func adError(message: String) {
-        let error = NSError(domain: "tv.superawesome.SAAdMobBannerAd",
+        let error = NSError(domain: AwesomeAds.info()?.bundle ?? "",
                             code: 0,
                             userInfo: [ NSLocalizedDescriptionKey: message])
         

--- a/SuperAwesomeAdMob.podspec
+++ b/SuperAwesomeAdMob.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Adapters/AdMob/Classes/**/*'
-  s.dependency 'SuperAwesome', '~> 7.2'
+  s.dependency 'SuperAwesome', '~> 8.5'
   s.dependency 'Google-Mobile-Ads-SDK'
   s.xcconfig = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ADMOB_PLUGIN',
                  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) ADMOB_PLUGIN=1' }


### PR DESCRIPTION
Refactor admob integration code Part 1 which includes converting the BannerAd to Swift.
The second part will contain the same for interstitial and video ads

Also this PR fixes compile issue when we upgrade the dependency of `SuperAwesome` sdk from 7.x to 8.5

## JIRA
[AAG-2724]

## DESCRIPTION
Refactor admob integration code to support newer versions of `AwesomeAds`



[AAG-2724]: https://superawesomeltd.atlassian.net/browse/AAG-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ