### PR TITLE
AAG-2775: iOS Banner Webview constraints

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,15 +7,15 @@ use_frameworks!
 target 'SuperAwesomeExample' do
   pod 'SuperAwesome', :path => '../'
 
-  pod 'Firebase/AnalyticsWithoutAdIdSupport'
-  pod 'FirebaseDatabaseSwift'
+  pod 'Firebase/AnalyticsWithoutAdIdSupport', '~> 9.6.0'
+  pod 'FirebaseDatabaseSwift', '~> 9.6.0'
 
   target 'SuperAwesomeExampleTests' do
     inherit! :search_paths
-    pod 'Nimble'
+    pod 'Nimble', '~> 10.0.0'
   end
 
   target 'SuperAwesomeExampleUITests' do
-    pod 'DominantColor'
+    pod 'DominantColor', '~> 0.2.0'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.2.0):
+  - GoogleDataTransport (9.2.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -86,10 +86,10 @@ PODS:
   - SwiftyXMLParser (5.6.0)
 
 DEPENDENCIES:
-  - DominantColor
-  - Firebase/AnalyticsWithoutAdIdSupport
-  - FirebaseDatabaseSwift
-  - Nimble
+  - DominantColor (~> 0.2.0)
+  - Firebase/AnalyticsWithoutAdIdSupport (~> 9.6.0)
+  - FirebaseDatabaseSwift (~> 9.6.0)
+  - Nimble (~> 10.0.0)
   - SuperAwesome (from `../`)
 
 SPEC REPOS:
@@ -132,7 +132,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
   FirebaseSharedSwift: 2269c2ddc7a5efb7fb5f3f3177e790613b52dfda
   GoogleAppMeasurement: 6de2b1a69e4326eb82ee05d138f6a5cb7311bcb1
-  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
+  GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
@@ -142,6 +142,6 @@ SPEC CHECKSUMS:
   SuperAwesome: 21b0978a1908e91fcf5bf2b6fe3fcd3a9985235d
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
-PODFILE CHECKSUM: cdfba0552c4704342023f282cacf6709606fe00b
+PODFILE CHECKSUM: e96ca02eee789b351485773c161d13dce92d8d96
 
 COCOAPODS: 1.11.3

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
   - nanopb/encode (2.30909.0)
   - Nimble (10.0.0)
   - PromisesObjC (2.1.1)
-  - SuperAwesome (8.5.0):
+  - SuperAwesome (8.5.1):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -139,7 +139,7 @@ SPEC CHECKSUMS:
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  SuperAwesome: dcacdc306c556d887d9111660b1a6c162113491b
+  SuperAwesome: 21b0978a1908e91fcf5bf2b6fe3fcd3a9985235d
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: cdfba0552c4704342023f282cacf6709606fe00b

--- a/Pod/Classes/UI/Banner/BannerView.swift
+++ b/Pod/Classes/UI/Banner/BannerView.swift
@@ -227,10 +227,10 @@ public class BannerView: UIView, Injectable {
             let aspectRatio = controller.adResponse?.aspectRatio() ?? 1.0
             logger.info("aspectRatio(): \(aspectRatio)")
             NSLayoutConstraint.activate([
-                view.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 1.0, constant: 0),
-                view.heightAnchor.constraint(lessThanOrEqualTo: self.heightAnchor, multiplier: 1.0, constant: 0),
-                view.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: 0),
-                view.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0)
+                view.topAnchor.constraint(equalTo: self.topAnchor),
+                view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+                view.trailingAnchor.constraint(equalTo: self.trailingAnchor)
             ])
         }
     }


### PR DESCRIPTION
## JIRA
[AAG-2775]

## DESCRIPTION
This PR updates the constraints for the embedded Web View in the BannerView, instead of letting this view decide it's width and height, we strictly specify the size using the parent view frame, I don't understand how this worked prior.
 
⚠️  **IMPORTANT:** This PR contains a compile fix, the Firebase dependencies in the example pod file were not version locked and due to this there were compile errors in another Google framework. ⚠️ 

## SCREENSHOTS
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-24 at 16 19 48](https://user-images.githubusercontent.com/618350/214348442-e625c314-76ef-4957-99b6-f177304d64e1.png)

[AAG-2775]: https://superawesomeltd.atlassian.net/browse/AAG-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ