### PR TITLE
AAG-2816: UI test split and CRON job for UI tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,8 +253,10 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "52 10 * * 1-5"
+          cron: "0 7 * * 1-5"
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only:
                 - develop
@@ -262,6 +264,8 @@ workflows:
       - checkout_code:
           context: MOBILE_IOS_SDKS
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -270,6 +274,8 @@ workflows:
           requires:
             - checkout_code
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -311,7 +317,7 @@ workflows:
             tags:
               ignore: /^v.*/
             branches:
-              ignore: develop
+              only: /ui-tests\/.*/
 
   develop:
     jobs:
@@ -326,6 +332,8 @@ workflows:
           requires:
             - checkout_code
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -334,6 +342,8 @@ workflows:
           requires:
             - checkout_code
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -342,6 +352,8 @@ workflows:
           requires:
             - checkout_code
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -350,6 +362,8 @@ workflows:
           requires:
             - test_superawesome_base_unit_tests
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -358,6 +372,8 @@ workflows:
           requires:
             - semantic_release_dry_run
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -366,6 +382,8 @@ workflows:
           requires:
             - approve_dry_run_and_release
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 
@@ -374,6 +392,8 @@ workflows:
           requires:
             - auto_update_release_version
           filters:
+            tags:
+              ignore: /^v.*/
             branches:
               only: develop
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "45 10 * * 1-5"
+          cron: "52 10 * * 1-5"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 # .circleci/config.yml
 version: 2.1
+
+dependencies:
+  pre:
+  - curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
+
 references:
 
   ios_config: &ios_config
@@ -72,13 +77,10 @@ jobs:
       - store_test_results:
           path: result.xml
 
-  # Run unit and UI tests
-  test_superawesome_base:
+  # Run unit tests
+  test_superawesome_base_unit_tests:
     <<: *ios_config
     environment:
-      FL_OUTPUT_DIR: output
-      IOS_IPHONE_UI_TEST_DEVICE: "iPhone SE (3rd generation) (16.2)"
-      IOS_IPAD_UI_TEST_DEVICE: "iPad Pro (11-inch) (4th generation) (16.2)"
       SA_IOS_SDKS_SCHEME: "SuperAwesomeExample"
       SA_IOS_SDKS_PATH_TO_WORKSPACE: "Example/SuperAwesomeExample"
       SA_IOS_SDKS_PODFILE_PATH: "./Example/Podfile"
@@ -97,10 +99,47 @@ jobs:
             /usr/bin/java -jar WireMock.jar &
             cd ../../../
             fastlane run_all_tests
-      - store_artifacts:
-          path: output
       - store_test_results:
-          path: output/scan
+          path: "./fastlane/test_output"
+      - store_artifacts:
+          path: "./fastlane/test_output"
+          destination: scan-test-output
+      - store_artifacts:
+          path: ~/Library/Logs/scan
+          destination: scan-logs
+
+  # Run ui tests
+  test_superawesome_base_ui_tests:
+    <<: *ios_config
+    environment:
+      IOS_IPHONE_UI_TEST_DEVICE: "iPhone SE (3rd generation) (16.2)"
+      IOS_IPAD_UI_TEST_DEVICE: "iPad Pro (11-inch) (4th generation) (16.2)"
+      SA_IOS_SDKS_SCHEME: "SuperAwesomeExample - UITests"
+      SA_IOS_SDKS_PATH_TO_WORKSPACE: "Example/SuperAwesomeExample"
+      SA_IOS_SDKS_PODFILE_PATH: "./Example/Podfile"
+      TERM: xterm-256color
+    steps:
+      - attach_workspace:
+          at: .
+      - *generate_github_token
+      - *clone_scripts_repo
+      - *bootstrap_ios
+      - *configure_google_services
+      - run:
+          name: Fastlane
+          command: |
+            cd Example/SuperAwesomeExampleUITests/MockServer
+            /usr/bin/java -jar WireMock.jar &
+            cd ../../../
+            fastlane run_all_tests
+      - store_test_results:
+          path: "./fastlane/test_output"
+      - store_artifacts:
+          path: "./fastlane/test_output"
+          destination: scan-test-output
+      - store_artifacts:
+          path: ~/Library/Logs/scan
+          destination: scan-logs
 
   semantic_release_dry_run:
     <<: *ios_config
@@ -211,10 +250,36 @@ jobs:
           command: fastlane sdk_push isPrivateRepo:false skipVersionBump:true
           
 workflows:
-  build-test:
+  nightly:
+   triggers:
+    - schedule:
+       cron: "0 7 * * 1-5"
+       filters:
+         branches:
+           only:
+             - develop
+  jobs:
+    - checkout_code:
+          context: MOBILE_IOS_SDKS
+          branches:
+              only: develop
+
+    - test_superawesome_base_ui_tests:
+          context: MOBILE_IOS_SDKS
+          requires:
+            - checkout_code
+          branches:
+              only: develop
+
+  pull_request:
     jobs:
       - checkout_code:
           context: MOBILE_IOS_SDKS
+          filters:
+            tags:
+              ignore: /^v.*/
+            branches:
+              ignore: develop
 
       - swiftlint:
           context: MOBILE_IOS_SDKS
@@ -223,19 +288,64 @@ workflows:
           filters:
             tags:
               ignore: /^v.*/
+            branches:
+              ignore: develop
 
-      - test_superawesome_base:
+      - test_superawesome_base_unit_tests:
           context: MOBILE_IOS_SDKS
           requires:
             - checkout_code
           filters:
             tags:
               ignore: /^v.*/
+            branches:
+              ignore: develop
+
+      - test_superawesome_base_ui_tests:
+          context: MOBILE_IOS_SDKS
+          requires:
+            - checkout_code
+          filters:
+            tags:
+              ignore: /^v.*/
+            branches:
+              ignore: develop
+
+  develop:
+    jobs:
+      - checkout_code:
+          context: MOBILE_IOS_SDKS
+          branches:
+              only: develop
+
+      - swiftlint:
+          context: MOBILE_IOS_SDKS
+          requires:
+            - checkout_code
+          filters:
+            branches:
+              only: develop
+
+      - test_superawesome_base_unit_tests:
+          context: MOBILE_IOS_SDKS
+          requires:
+            - checkout_code
+          filters:
+            branches:
+              only: develop
+
+      - test_superawesome_base_ui_tests:
+          context: MOBILE_IOS_SDKS
+          requires:
+            - checkout_code
+          filters:
+            branches:
+              only: develop
 
       - semantic_release_dry_run:
           context: MOBILE_IOS_SDKS
           requires:
-            - test_superawesome_base
+            - test_superawesome_base_unit_tests
           filters:
             branches:
               only: develop
@@ -263,6 +373,15 @@ workflows:
           filters:
             branches:
               only: develop
+
+  release:
+      - checkout_code:
+          context: MOBILE_IOS_SDKS
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
 
       - sdk_push_superawesome:
           context: MOBILE_IOS_SDKS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,8 +255,6 @@ workflows:
       - schedule:
           cron: "0 7 * * 1-5"
           filters:
-            tags:
-              ignore: /^v.*/
             branches:
               only:
                 - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
   nightly:
    triggers:
     - schedule:
-       cron: "0 7 * * 1-5"
+       cron: "45 10 * * 1-5"
        filters:
          branches:
            only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,24 +251,26 @@ jobs:
           
 workflows:
   nightly:
-   triggers:
-    - schedule:
-       cron: "45 10 * * 1-5"
-       filters:
-         branches:
-           only:
-             - develop
-  jobs:
-    - checkout_code:
+    triggers:
+      - schedule:
+          cron: "45 10 * * 1-5"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - checkout_code:
           context: MOBILE_IOS_SDKS
-          branches:
+          filters:
+            branches:
               only: develop
 
-    - test_superawesome_base_ui_tests:
+      - test_superawesome_base_ui_tests:
           context: MOBILE_IOS_SDKS
           requires:
             - checkout_code
-          branches:
+          filters:
+            branches:
               only: develop
 
   pull_request:
@@ -315,7 +317,8 @@ workflows:
     jobs:
       - checkout_code:
           context: MOBILE_IOS_SDKS
-          branches:
+          filters:
+            branches:
               only: develop
 
       - swiftlint:
@@ -375,6 +378,7 @@ workflows:
               only: develop
 
   release:
+    jobs:
       - checkout_code:
           context: MOBILE_IOS_SDKS
           filters:

--- a/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesomeExample - UITests.xcscheme
+++ b/Example/SuperAwesomeExample.xcodeproj/xcshareddata/xcschemes/SuperAwesomeExample - UITests.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1B76D2321C91EEB1000AE8F3"
+               BuildableName = "SuperAwesomeExample.app"
+               BlueprintName = "SuperAwesomeExample"
+               ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC6AE3CD284F906B002F7581"
+               BuildableName = "SuperAwesomeExampleUITests.xctest"
+               BlueprintName = "SuperAwesomeExampleUITests"
+               ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "VideoAdUITests/testCloseButtonAppearsWithDelay_WhenConfigured()">
+               </Test>
+               <Test
+                  Identifier = "VideoAdUITests/testNonKSF_VPAID_ad_loads_successfully()">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B76D2321C91EEB1000AE8F3"
+            BuildableName = "SuperAwesomeExample.app"
+            BlueprintName = "SuperAwesomeExample"
+            ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B76D2321C91EEB1000AE8F3"
+            BuildableName = "SuperAwesomeExample.app"
+            BlueprintName = "SuperAwesomeExample"
+            ReferencedContainer = "container:SuperAwesomeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## JIRA
[AAG-2816]

## DESCRIPTION
This PR adds a new scheme to the iOS project for UI tests only, unit tests are run against the main example app scheme.

I have also cleaned up the workflows to make them more explicit and easier to maintain.

The CRON job runs UI tests every weekday morning at 7am.

When building UI tests, if you prefix the branch with: `ui-tests/` e.g. `ui-tests/aag-xxxx-this-is-a-ui-test` the UI test job will run on that branch when a pull request is raised.

## SCREENSHOTS
![Screenshot 2023-02-08 at 11 10 49](https://user-images.githubusercontent.com/618350/217513715-113400c4-5a48-4d1f-80bb-f3f4ab4f5587.png)

[AAG-2816]: https://superawesomeltd.atlassian.net/browse/AAG-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ