### PR TITLE
fix(): AdMob custom adapters

### DIFF
--- a/Adapters/AdMob/Classes/SAAdMobAdapter.h
+++ b/Adapters/AdMob/Classes/SAAdMobAdapter.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+@import GoogleMobileAds;
+@import SuperAwesome;
+
+@interface SAAdMobAdapter : NSObject <GADMediationAdapter>
+@end

--- a/Adapters/AdMob/Classes/SAAdMobAdapter.m
+++ b/Adapters/AdMob/Classes/SAAdMobAdapter.m
@@ -1,0 +1,61 @@
+#import "SAAdMobAdapter.h"
+#import "SAAdMobExtras.h"
+#import "SAAdMobRewardedAd.h"
+#import "SAAdMobBannerAd.h"
+#import "SAAdMobInterstitialAd.h"
+#include <stdatomic.h>
+
+#define kERROR_DOMAIN @"tv.superawesome.SAAdMobAdapter"
+
+@implementation SAAdMobAdapter {
+    SAAdMobRewardedAd *_rewardedAd;
+    SAAdMobBannerAd *_bannerAd;
+    SAAdMobInterstitialAd *_interstitialAd;
+}
+
++ (GADVersionNumber) adSDKVersion {
+    NSString *versionString = [[AwesomeAds info] versionNumber];
+    NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
+    GADVersionNumber version = {0};
+    if (versionComponents.count == 3) {
+        version.majorVersion = [versionComponents[0] integerValue];
+        version.minorVersion = [versionComponents[1] integerValue];
+        version.patchVersion = [versionComponents[2] integerValue];
+    }
+    return version;
+}
+
++ (GADVersionNumber) adapterVersion {
+    NSString *versionString = [[AwesomeAds info] versionNumber];
+    NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
+    GADVersionNumber version = {0};
+    if (versionComponents.count == 3) {
+        version.majorVersion = [versionComponents[0] integerValue];
+        version.minorVersion = [versionComponents[1] integerValue];
+        version.patchVersion = [versionComponents[2] integerValue];
+    }
+    return version;
+}
+
++ (Class<GADAdNetworkExtras>)networkExtrasClass {
+    return [SAAdMobVideoExtra class];
+}
+
+- (void)loadRewardedAdForAdConfiguration: (GADMediationRewardedAdConfiguration *)adConfiguration
+                       completionHandler: (GADMediationRewardedLoadCompletionHandler)completionHandler {
+    _rewardedAd = [[SAAdMobRewardedAd alloc] init];
+    [_rewardedAd loadRewardedAdForAdConfiguration:adConfiguration
+                                completionHandler:completionHandler];
+}
+
+- (void)loadBannerForAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration completionHandler:(GADMediationBannerLoadCompletionHandler)completionHandler {
+    _bannerAd = [[SAAdMobBannerAd alloc] init];
+    [_bannerAd loadBannerForAdConfiguration:adConfiguration completionHandler:completionHandler];
+}
+
+- (void)loadInterstitialForAdConfiguration:(GADMediationInterstitialAdConfiguration *)adConfiguration completionHandler:(GADMediationInterstitialLoadCompletionHandler)completionHandler {
+    _interstitialAd = [[SAAdMobInterstitialAd alloc] init];
+    [_interstitialAd loadInterstitialForAdConfiguration:adConfiguration completionHandler:completionHandler];
+}
+
+@end

--- a/Adapters/AdMob/Classes/SAAdMobBannerAd.m
+++ b/Adapters/AdMob/Classes/SAAdMobBannerAd.m
@@ -88,20 +88,20 @@
     
     [_bannerAd setCallback:^(NSInteger placementId, SAEvent event) {
         switch (event) {
+            case SAEventAdAlreadyLoaded:
             case SAEventAdLoaded: {
                 [weakSelf adLoaded];
                 break;
             }
-            case SAEventAdEmpty: {
-                [weakSelf adFailed];
-                break;
-            }
+            case SAEventAdEmpty:
+            case SAEventAdFailedToShow:
             case SAEventAdFailedToLoad: {
                 [weakSelf adFailed];
                 break;
             }
             case SAEventAdShown: {
                 [weakSelf.delegate willPresentFullScreenView];
+                [weakSelf.delegate reportImpression];
                 break;
             }
             case SAEventAdClicked: {
@@ -113,9 +113,9 @@
                 [weakSelf.delegate willDismissFullScreenView];
                 [weakSelf.delegate didDismissFullScreenView];
                 break;
-            //
-            // non supported SA events
-            default:
+            }
+            case SAEventAdEnded: {
+                [weakSelf.delegate didDismissFullScreenView];
                 break;
             }
         }

--- a/Adapters/AdMob/Classes/SAAdMobBannerCustomEvent.h
+++ b/Adapters/AdMob/Classes/SAAdMobBannerCustomEvent.h
@@ -2,5 +2,6 @@
 @import GoogleMobileAds;
 @import SuperAwesome;
 
+__attribute__((deprecated("Use SAAdMobAdapter instead")))
 @interface SAAdMobBannerCustomEvent : NSObject <GADMediationAdapter>
 @end

--- a/Adapters/AdMob/Classes/SAAdMobInterstitialAd.m
+++ b/Adapters/AdMob/Classes/SAAdMobInterstitialAd.m
@@ -81,20 +81,20 @@
     
     [SAInterstitialAd setCallback:^(NSInteger placementId, SAEvent event) {
         switch (event) {
+            case SAEventAdAlreadyLoaded:
             case SAEventAdLoaded: {
                 [weakSelf adLoaded];
                 break;
             }
-            case SAEventAdEmpty: {
-                [weakSelf adFailed];
-                break;
-            }
+            case SAEventAdEmpty:
+            case SAEventAdFailedToShow:
             case SAEventAdFailedToLoad: {
                 [weakSelf adFailed];
                 break;
             }
             case SAEventAdShown: {
                 [weakSelf.delegate willPresentFullScreenView];
+                [weakSelf.delegate reportImpression];
                 break;
             }
             case SAEventAdClicked: {
@@ -106,9 +106,9 @@
                 [weakSelf.delegate willDismissFullScreenView];
                 [weakSelf.delegate didDismissFullScreenView];
                 break;
-            //
-            // non supported SA events
-            default:
+            }
+            case SAEventAdEnded: {
+                [weakSelf.delegate didDismissFullScreenView];
                 break;
             }
         }

--- a/Adapters/AdMob/Classes/SAAdMobInterstitialCustomEvent.h
+++ b/Adapters/AdMob/Classes/SAAdMobInterstitialCustomEvent.h
@@ -2,5 +2,6 @@
 @import GoogleMobileAds;
 @import SuperAwesome;
 
+__attribute__((deprecated("Use SAAdMobAdapter instead")))
 @interface SAAdMobInterstitialCustomEvent : NSObject <GADMediationAdapter>
 @end

--- a/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
+++ b/Adapters/AdMob/Classes/SAAdMobRewardedAd.m
@@ -2,7 +2,7 @@
 #import "SAAdMobExtras.h"
 #include <stdatomic.h>
 
-#define kERROR_DOMAIN @"tv.superawesome.SAAdMobVideoMediationAdapter"
+#define kERROR_DOMAIN @"tv.superawesome.SAAdMobRewardedAd"
 
 @interface SAAdMobRewardedAd () <GADMediationRewardedAd> {
     
@@ -85,22 +85,22 @@
     __weak typeof (self) weakSelf = self;
     
     [SAVideoAd setCallback:^(NSInteger placementId, SAEvent event) {
-        
         switch (event) {
+            case SAEventAdAlreadyLoaded:
             case SAEventAdLoaded: {
                 [weakSelf adLoaded];
                 break;
             }
-            case SAEventAdEmpty: {
-                [weakSelf adFailed];
-                break;
-            }
+            case SAEventAdEmpty:
+            case SAEventAdFailedToShow:
             case SAEventAdFailedToLoad: {
                 [weakSelf adFailed];
                 break;
             }
             case SAEventAdShown: {
                 [weakSelf.delegate willPresentFullScreenView];
+                [weakSelf.delegate didStartVideo];
+                [weakSelf.delegate reportImpression];
                 break;
             }
             case SAEventAdClicked: {
@@ -110,15 +110,13 @@
             }
             case SAEventAdClosed: {
                 [weakSelf.delegate willDismissFullScreenView];
+                [weakSelf.delegate didEndVideo];
                 [weakSelf.delegate didDismissFullScreenView];
                 break;
             }
-            case SAEventAdAlreadyLoaded:
-            case SAEventAdFailedToShow:
             case SAEventAdEnded: {
                 GADAdReward *reward = [[GADAdReward alloc] initWithRewardType:@"Reward"
                                                                  rewardAmount:[[NSDecimalNumber alloc] initWithInt:1]];
-                
                 [weakSelf.delegate didRewardUserWithReward: reward];
                 break;
             }

--- a/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.h
+++ b/Adapters/AdMob/Classes/SAAdMobVideoMediationAdapter.h
@@ -2,5 +2,6 @@
 @import GoogleMobileAds;
 @import SuperAwesome;
 
+__attribute__((deprecated("Use SAAdMobAdapter instead")))
 @interface SAAdMobVideoMediationAdapter : NSObject <GADMediationAdapter>
 @end

--- a/Adapters/AdMob/Example/Podfile.lock
+++ b/Adapters/AdMob/Example/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
   - Alamofire (5.6.4)
-  - Google-Mobile-Ads-SDK (10.0.0):
+  - Google-Mobile-Ads-SDK (10.1.0):
     - GoogleAppMeasurement (< 11.0, >= 7.0)
     - GoogleUserMessagingPlatform (>= 1.1)
-  - GoogleAppMeasurement (10.4.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.4.0)
+  - GoogleAppMeasurement (10.5.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.4.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.4.0)
+  - GoogleAppMeasurement/AdIdSupport (10.5.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.4.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.5.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
@@ -50,11 +50,11 @@ PODS:
     - nanopb/encode (= 2.30909.0)
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
-  - PromisesObjC (2.1.1)
-  - SuperAwesome (8.5.1):
+  - PromisesObjC (2.2.0)
+  - SuperAwesome (8.5.4):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
-  - SuperAwesomeAdMob (8.5.1):
+  - SuperAwesomeAdMob (8.5.4):
     - Google-Mobile-Ads-SDK
     - SuperAwesome (~> 8.5)
   - SwiftyXMLParser (5.6.0)
@@ -81,15 +81,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
-  Google-Mobile-Ads-SDK: 02b68fc1dd65d011dd5e61e204a7d0cee79b8a85
-  GoogleAppMeasurement: 173fa22ce7d62c29332568e853b39b2525a0e584
+  Google-Mobile-Ads-SDK: 894be2e3e3e8281004bda14381f9af7ad73eeffd
+  GoogleAppMeasurement: 40c70a7d89013f0eca72006c4b9732163ea4cdae
   GoogleUserMessagingPlatform: 5f8b30daf181805317b6b985bb51c1ff3beca054
   GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  SuperAwesome: 21b0978a1908e91fcf5bf2b6fe3fcd3a9985235d
-  SuperAwesomeAdMob: dd3e7ac39d1493f591c26067e8a593c29845c3b2
+  PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
+  SuperAwesome: 651dff96ca660d57f684896d9c25d4c10baa6c23
+  SuperAwesomeAdMob: add542f805f578405e9d9a5075eadd4b79978fb2
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: 03d6202dab31308246e74393b6a652006c4c7240

--- a/Example/SuperAwesomeExampleTests/Common/Mocks/AdProcessorMock.swift
+++ b/Example/SuperAwesomeExampleTests/Common/Mocks/AdProcessorMock.swift
@@ -8,7 +8,7 @@
 @testable import SuperAwesome
 
 class AdProcessorMock: AdProcessorType {
-    func process(_ placementId: Int, _ ad: Ad, _ requestOptions: [String : Any]?, completion: @escaping OnComplete<AdResponse>) {
+    func process(_ placementId: Int, _ ad: Ad, _ requestOptions: [String: Any]?, completion: @escaping OnComplete<AdResponse>) {
         completion(AdResponse(placementId, ad, requestOptions))
     }
 }

--- a/Example/SuperAwesomeSwiftUIExample/Views/Screens/FeatureDetailView.swift
+++ b/Example/SuperAwesomeSwiftUIExample/Views/Screens/FeatureDetailView.swift
@@ -14,7 +14,7 @@ struct FeatureDetailView: View {
     private let padding = 16.0
 
     @State var feature: FeatureItem
-    @State private var selectedPlacement: PlacementItem? = nil
+    @State private var selectedPlacement: PlacementItem?
     @State private var isTestModeEnabled: Bool = false
     @State private var isBumperEnabled: Bool = false
     @State private var isParentGateEnabled: Bool = false

--- a/Pod/Classes/Common/Components/AdQueryMaker.swift
+++ b/Pod/Classes/Common/Components/AdQueryMaker.swift
@@ -114,7 +114,7 @@ class AdQueryMaker: AdQueryMakerType {
 
     private func merge( _ new: [String: Any], with original: inout [String: Any]) {
         for (key, value) in new {
-            switch(value) {
+            switch value {
             case let value as String:
                 original[key] = value
             case let value as Int:

--- a/Pod/Classes/Common/PropertyWrappers/CodableExcluded.swift
+++ b/Pod/Classes/Common/PropertyWrappers/CodableExcluded.swift
@@ -27,4 +27,3 @@ extension CodableExcluded: Codable {
         self.value = nil
     }
 }
-

--- a/Pod/Classes/UI/Video/VideoAd.swift
+++ b/Pod/Classes/UI/Video/VideoAd.swift
@@ -35,7 +35,6 @@ public class VideoAd: NSObject, Injectable {
     // Internal control methods
     ////////////////////////////////////////////////////////////////////////////
 
-
     /**
      * Method that loads an ad into the queue.
      * Ads can only be loaded once and then can be reloaded after they've


### PR DESCRIPTION
## JIRA
[AAG-2844]

## DESCRIPTION
fix(): AdMob custom adapters so that the correct events are passed through the admob plugin from the awesome ads sdk
- Adds a new class to combine different type of custom ad formats called `SAAdMobAdapter` to align with Android SDK
- Deprecated the following custom event classes and instead suggested to use the new `SAAdMobAdapter` `SAAdMobBannerCustomEvent`
`SAAdMobInterstitialCustomEvent`
`SAAdMobVideoMediationAdapter`


[AAG-2844]: https://superawesomeltd.atlassian.net/browse/AAG-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ