### PR TITLE
AAG-2861: Changed the caching policy on all network requests

### DIFF
--- a/Pod/Classes/Network/DataSources/AFNetworkDataSource.swift
+++ b/Pod/Classes/Network/DataSources/AFNetworkDataSource.swift
@@ -8,8 +8,15 @@
 import Alamofire
 
 class AFNetworkDataSource: NetworkDataSourceType {
+
+    private lazy var networking: Session = {
+        let sessionConfig = URLSessionConfiguration.af.default
+        sessionConfig.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        return Session.init(configuration: sessionConfig)
+    }()
+
     func getData(url: String, completion: OnResult<Data>?) {
-        AF.request(url).responseData { response in
+        networking.request(url).responseData { response in
             if let data = response.data {
                 completion?(Result.success(data))
             } else {
@@ -34,7 +41,7 @@ class AFNetworkDataSource: NetworkDataSourceType {
             return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
         }
 
-        AF.download(url, to: destination).response { response in
+        networking.download(url, to: destination).response { response in
             debugPrint(response)
 
             if response.error == nil, let path = response.fileURL?.path {


### PR DESCRIPTION
## JIRA
[AAG-2861]

## DESCRIPTION
Changed the caching policy on all network requests made by the SA SDK to ignore cache on both local and remote.
The default Alamofire caching policy of load from disk was enabled, this is now set to ignore both local and remote caches.

## SCREENSHOTS
n/a


[AAG-2861]: https://superawesomeltd.atlassian.net/browse/AAG-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ