### PR TITLE
chore(): Added a helper to get a CloseButtonState from an int

### DIFF
--- a/Pod/Classes/Common/State/CloseButtonState.swift
+++ b/Pod/Classes/Common/State/CloseButtonState.swift
@@ -5,8 +5,18 @@
 //  Created by Tom O'Rourke on 08/06/2022.
 //
 
-enum CloseButtonState {
-    case visibleWithDelay
-    case visibleImmediately
-    case hidden
+@objc
+public enum CloseButtonState: Int {
+    case visibleWithDelay = 0
+    case visibleImmediately = 1
+    case hidden = 2
+}
+
+@objc
+public class CloseButtonStateHelper: NSObject {
+    /// Creates a `CloseButtonState` enum from an `int` value.
+    @objc
+    public class func from(_ value: Int) -> CloseButtonState {
+        CloseButtonState(rawValue: value) ?? Constants.defaultCloseButton
+    }
 }


### PR DESCRIPTION
## JIRA
[AAG-2880)]

## DESCRIPTION

This PR adds a close button state helper to set the close button state from the Unity Objective-C wrapper. It follows the approach of the `OrientationHelper`. The idea is that the bridging Objective-C takes an `int` from the C#.


## SCREENSHOTS
n/a
