### PR TITLE
Fix/aag 2996 direct video black screen issues

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
   - Nimble (10.0.0)
-  - SuperAwesome (8.5.6):
+  - SuperAwesome (8.5.7):
     - Moya (~> 14.0)
     - SwiftyXMLParser (= 5.6.0)
   - SwiftyXMLParser (5.6.0)
@@ -33,7 +33,7 @@ SPEC CHECKSUMS:
   DominantColor: 960c25e8d7eaf598bb5adae5c99a67a205ad3099
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  SuperAwesome: 49467de69f9c6c87381820852ea966918b5e632e
+  SuperAwesome: 6197541d1f2f3e3401cb51cb09a4d398444b9820
   SwiftyXMLParser: 9b98995235961881322015ebe38d1f3d7c953bd7
 
 PODFILE CHECKSUM: 1d2a860c705998b097bbe2d8bb6add23bf19e9af

--- a/Pod/Classes/UI/Managed/SAManagedAdViewController.swift
+++ b/Pod/Classes/UI/Managed/SAManagedAdViewController.swift
@@ -61,8 +61,7 @@ import WebKit
     func close() {
         managedAdView.close()
         controller.close()
-
-        dismiss(animated: true, completion: nil)
+        view.window?.rootViewController?.dismiss(animated: true)
     }
 
     private func configureCloseButton() {

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -182,10 +182,9 @@ import UIKit
     }
 
     private func close() {
+        controller.close()
         videoPlayer.destroy()
-        view.window?.rootViewController?.dismiss(animated: true) { [weak self] in
-            self?.controller.close()
-        }
+        view.window?.rootViewController?.dismiss(animated: true)
     }
 }
 

--- a/Pod/Classes/UI/Video/VideoViewController.swift
+++ b/Pod/Classes/UI/Video/VideoViewController.swift
@@ -183,7 +183,7 @@ import UIKit
 
     private func close() {
         videoPlayer.destroy()
-        dismiss(animated: true) { [weak self] in
+        view.window?.rootViewController?.dismiss(animated: true) { [weak self] in
             self?.controller.close()
         }
     }


### PR DESCRIPTION
## JIRA
[AAG-2996]

## DESCRIPTION

This PR fixes an issue with direct video where a black screen was appearing if the parental gate / bumper was still present when closing the ad. This was due to `dismiss` only dismissing the parental gate / bumper and the `videoPlayer` being destroyed (the view being removed from the view hierachy). The change now dismisses all presented modals.

## SCREENSHOTS
n/a


[AAG-2996]: https://superawesomeltd.atlassian.net/browse/AAG-2996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ