### PR TITLE
fix(CI): Locked in Circle CI macos.x86.medium.gen2 resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ references:
   ios_config: &ios_config
     macos:
       xcode: 14.2.0
+    resource_class: macos.x86.medium.gen2
     environment:
       FL_OUTPUT_DIR: output
       LC_ALL: en_GB.UTF-8


### PR DESCRIPTION
## JIRA
NO-JIRA

## DESCRIPTION
Locked in Circle CI macos.x86.medium.gen2 resource class

## SCREENSHOTS
n/a
